### PR TITLE
Ensure only shell can change yarn.lock

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .cache
 build
 node_modules
+node_modules/
 public
 README.md
 neon_law.egg-info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ x-shared-variables: &shared-variables
 x-javascript-volumes: &javascript-volumes
   - ./:/app
   - node_modules:/app/node_modules
+  - ./yarn.lock:/app/yarn.lock:ro
 
 services:
   postgres:


### PR DESCRIPTION
This commit enforces that yarn.lock is a read-only file within the
non-shell containers, so that the only updates to packages happen from
the shell container that you are encouraged to Attach to when building
this application.