### PR TITLE
add color to the inline code styles.

### DIFF
--- a/packages/shared-ui/src/styles/base.tsx
+++ b/packages/shared-ui/src/styles/base.tsx
@@ -67,6 +67,10 @@ const BaseStyles = (): JSX.Element => (
         }
       }
 
+      code {
+        color: ${colors.text.darkLight} !important;
+      }
+
       /* ---------------------------------- */
       /* ----- Links & Buttons ----- */
       /* ---------------------------------- */


### PR DESCRIPTION
Fixes #656

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/89955899-73b42600-dc4d-11ea-88bf-c1f77d81ac64.png)


I was not able o figure out How to change the colour using the API provided by `prism-react-renderer`. 

Also, what do you say about using `https://www.gatsbyjs.org/packages/gatsby-remark-prismjs/` instead of `prisim-react-renderer` which has an easy and well-documented API? 