### PR TITLE
Move saving PDF into separate useEffect function

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
         "babel-preset-gatsby": "^0.5.4",
         "cypress-axe": "^0.8.1",
         "cypress-plugin-tab": "^1.0.5",
-        "eslint": "^7.5.0",
         "eslint-plugin-import": "^2.22.0",
         "eslint-plugin-jest": "^23.20.0",
         "eslint-plugin-react-hooks": "^4.1.0",

--- a/packages/print/README.md
+++ b/packages/print/README.md
@@ -7,5 +7,5 @@ A CLI to parse MDX files and generate PDFs
 In the root of this directory, run:
 
 ```
-yarn run-script ./packages/print/src/index.tsx --file=./path/to.md
+yarn run-script ./packages/print/src/index.tsx --file ./path/to.mdx
 ```

--- a/packages/print/package.json
+++ b/packages/print/package.json
@@ -13,6 +13,7 @@
     "@hookform/error-message": "^0.0.4",
     "@mdx-js/mdx": "^1.6.16",
     "@mdx-js/react": "^1.6.14",
+    "@mdx-js/runtime": "^1.6.14",
     "@reach/router": "^1.3.4",
     "@react-pdf/renderer": "^2.0.0-beta.14",
     "emotion-theming": "^10.0.27",

--- a/packages/print/src/index.tsx
+++ b/packages/print/src/index.tsx
@@ -1,5 +1,6 @@
 import {
   Document,
+  Font,
   Page,
   default as ReactPDF,
   StyleSheet,
@@ -7,19 +8,50 @@ import {
   View
 } from '@react-pdf/renderer';
 import { Text as InkText, render } from 'ink';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { argv } from 'yargs';
+import mdx from '@mdx-js/mdx';
 import { readFileSync } from 'fs';
+
+
+Font.register({
+  family: 'CharisSIL',
+  fontStyle: 'normal',
+  fontWeight: 400,
+  src: 'https://www.neonlaw.com/fonts/charis/CharisSIL-R.ttf'
+});
+Font.register({
+  family: 'CharisSIL',
+  fontStyle: 'italic',
+  fontWeight: 400,
+  src: 'https://www.neonlaw.com/fonts/charis/CharisSIL-I.ttf'
+});
+Font.register({
+  family: 'CharisSIL',
+  fontStyle: 'normal',
+  fontWeight: 700,
+  src: 'https://www.neonlaw.com/fonts/charis/CharisSIL-B.ttf'
+});
+Font.register({
+  family: 'CharisSIL',
+  fontStyle: 'italic',
+  fontWeight: 700,
+  src: 'https://www.neonlaw.com/fonts/charis/CharisSIL-BI.ttf'
+});
 
 const styles = StyleSheet.create({
   page: {
     backgroundColor: '#E4E4E4',
     flexDirection: 'row',
+    fontFamily: 'CharisSIL',
   },
   section: {
     flexGrow: 1,
     margin: 10,
     padding: 10,
+  },
+  text: {
+    fontFamily: 'CharisSIL'
   }
 });
 
@@ -27,52 +59,42 @@ const MyDocument = ({ text }) => (
   <Document>
     <Page size="A4" style={styles.page}>
       <View style={styles.section}>
-        <Text>{text}</Text>
+        <Text style={styles.text}>
+          rar
+        </Text>
+        <Text style={styles.text}>
+          {mdx.sync(text)}
+        </Text>
       </View>
     </Page>
   </Document>
 );
 
 const CLI = () => {
-  if (argv.file) {
-    try {
-      const filename = `${argv.file}`;
-      const file = readFileSync(filename, 'utf-8').toString();
+  const [pdfFile, saved] = useState(false);
 
-      ReactPDF.render(<MyDocument text={file} />, `${filename}.pdf`)
-        .then(res => {
-          console.log(res);
-          return (
-            <>
-              <InkText>Writing the PDF file: {`${filename}.pdf`}</InkText>
-            </>
-          );
-        })
-        .catch(err => {
-          console.log(err);
-          return (
-            <>
-              <InkText>Error, you need to pass in a valid --file</InkText>
-            </>
-          );
-        });
-    }
-    catch (err) {
-      console.log(err);
+  useEffect(() => {
+    savePdf();
+  });
 
-      return (
-        <>
-          <InkText>Error, you need to pass in a valid --file</InkText>
-        </>
-      );
-    }
-  }
+  const filename = `${argv.file}`;
+  const file = readFileSync(filename, 'utf-8').toString();
+
+  const savePdf = async () => {
+    if (!argv.file) { return; }
+    await ReactPDF.render(<MyDocument text={file} />, `${filename}.pdf`)
+      .then(() => saved(true))
+      .catch((err) => console.log(err));
+  };
 
   return (
     <>
-      <InkText>Error, you need to pass in a --file</InkText>
+      <InkText>
+        PDF file at {`${filename}.pdf`} is saved: {pdfFile ? 'true' : 'false'}
+      </InkText>
     </>
   );
+
 };
 
 render(<CLI />);

--- a/packages/shared-ui/src/themes/fonts.css
+++ b/packages/shared-ui/src/themes/fonts.css
@@ -126,8 +126,8 @@
 
 @font-face {
   font-family: 'CharisSIL';
-  src: url('/fonts/charis/CharisSil-R.tff') format('ttf'),
-    url('/fonts/charis/CharisSil-R.woff2') format('woff2');
+  src: url('/fonts/charis/CharisSIL-R.ttf') format('ttf'),
+    url('/fonts/charis/CharisSIL-R.woff2') format('woff2');
   font-style: normal;
   font-display: swap;
   font-weight: 400;
@@ -135,8 +135,8 @@
 
 @font-face {
   font-family: 'CharisSIL';
-  src: url('/fonts/charis/CharisSil-I.tff') format('ttf'),
-    url('/fonts/charis/CharisSil-I.woff2') format('woff2');
+  src: url('/fonts/charis/CharisSIL-I.ttf') format('ttf'),
+    url('/fonts/charis/CharisSIL-I.woff2') format('woff2');
   font-style: italic;
   font-display: swap;
   font-weight: 400;
@@ -144,8 +144,8 @@
 
 @font-face {
   font-family: 'CharisSIL';
-  src: url('/fonts/charis/CharisSil-B.tff') format('ttf'),
-    url('/fonts/charis/CharisSil-B.woff2') format('woff2');
+  src: url('/fonts/charis/CharisSIL-B.ttf') format('ttf'),
+    url('/fonts/charis/CharisSIL-B.woff2') format('woff2');
   font-style: normal;
   font-display: swap;
   font-weight: 700;
@@ -153,8 +153,8 @@
 
 @font-face {
   font-family: 'CharisSIL';
-  src: url('/fonts/charis/CharisSil-BI.tff') format('ttf'),
-    url('/fonts/charis/CharisSil-BI.woff2') format('woff2');
+  src: url('/fonts/charis/CharisSIL-BI.ttf') format('ttf'),
+    url('/fonts/charis/CharisSIL-BI.woff2') format('woff2');
   font-style: italic;
   font-display: swap;
   font-weight: 700;
@@ -162,7 +162,7 @@
 
 @font-face {
   font-family: 'Fira Mono';
-  src: url('/fonts/fira-mono/FiraMono-Medium.tff') format('ttf'),
+  src: url('/fonts/fira-mono/FiraMono-Medium.ttf') format('ttf'),
     url('/fonts/fira-mono/FiraMono-Medium.woff2') format('woff2');
   font-style: normal;
   font-display: swap;
@@ -171,7 +171,7 @@
 
 @font-face {
   font-family: 'Fira Mono';
-  src: url('/fonts/fira-mono/FiraMono-Regular.tff') format('ttf'),
+  src: url('/fonts/fira-mono/FiraMono-Regular.ttf') format('ttf'),
     url('/fonts/fira-mono/FiraMono-Regular.woff2') format('woff2');
   font-style: normal;
   font-display: swap;
@@ -180,7 +180,7 @@
 
 @font-face {
   font-family: 'Fira Mono';
-  src: url('/fonts/fira-mono/FiraMono-Bold.tff') format('ttf'),
+  src: url('/fonts/fira-mono/FiraMono-Bold.ttf') format('ttf'),
     url('/fonts/fira-mono/FiraMono-Bold.woff2') format('woff2');
   font-style: normal;
   font-display: swap;
@@ -189,7 +189,7 @@
 
 @font-face {
   font-family: 'Jost';
-  src: url('/fonts/jost/Jost-400-Hairline.tff') format('ttf'),
+  src: url('/fonts/jost/Jost-400-Hairline.ttf') format('ttf'),
     url('/fonts/jost/Jost-400-Hairline.woff2') format('woff2');
   font-style: normal;
   font-display: swap;
@@ -198,7 +198,7 @@
 
 @font-face {
   font-family: 'Jost';
-  src: url('/fonts/jost/Jost-400-HairlineItalic.tff') format('ttf'),
+  src: url('/fonts/jost/Jost-400-HairlineItalic.ttf') format('ttf'),
     url('/fonts/jost/Jost-400-HairlineItalic.woff2') format('woff2');
   font-style: italic;
   font-display: swap;
@@ -207,7 +207,7 @@
 
 @font-face {
   font-family: 'Jost';
-  src: url('/fonts/jost/Jost-400-Thin.tff') format('ttf'),
+  src: url('/fonts/jost/Jost-400-Thin.ttf') format('ttf'),
     url('/fonts/jost/Jost-400-Thin.woff2') format('woff2');
   font-style: normal;
   font-display: swap;
@@ -216,7 +216,7 @@
 
 @font-face {
   font-family: 'Jost';
-  src: url('/fonts/jost/Jost-400-ThinItalic.tff') format('ttf'),
+  src: url('/fonts/jost/Jost-400-ThinItalic.ttf') format('ttf'),
     url('/fonts/jost/Jost-400-ThinItalic.woff2') format('woff2');
   font-style: italic;
   font-display: swap;
@@ -225,7 +225,7 @@
 
 @font-face {
   font-family: 'Jost';
-  src: url('/fonts/jost/Jost-400-Light.tff') format('ttf'),
+  src: url('/fonts/jost/Jost-400-Light.ttf') format('ttf'),
     url('/fonts/jost/Jost-400-Light.woff2') format('woff2');
   font-style: normal;
   font-display: swap;
@@ -234,7 +234,7 @@
 
 @font-face {
   font-family: 'Jost';
-  src: url('/fonts/jost/Jost-400-LightItalic.tff') format('ttf'),
+  src: url('/fonts/jost/Jost-400-LightItalic.ttf') format('ttf'),
     url('/fonts/jost/Jost-400-LightItalic.woff2') format('woff2');
   font-style: italic;
   font-display: swap;
@@ -243,7 +243,7 @@
 
 @font-face {
   font-family: 'Jost';
-  src: url('/fonts/jost/Jost-400-Book.tff') format('ttf'),
+  src: url('/fonts/jost/Jost-400-Book.ttf') format('ttf'),
     url('/fonts/jost/Jost-400-Book.woff2') format('woff2');
   font-style: normal;
   font-display: swap;
@@ -252,7 +252,7 @@
 
 @font-face {
   font-family: 'Jost';
-  src: url('/fonts/jost/Jost-400-BookItalic.tff') format('ttf'),
+  src: url('/fonts/jost/Jost-400-BookItalic.ttf') format('ttf'),
     url('/fonts/jost/Jost-400-BookItalic.woff2') format('woff2');
   font-style: italic;
   font-display: swap;
@@ -261,7 +261,7 @@
 
 @font-face {
   font-family: 'Jost';
-  src: url('/fonts/jost/Jost-500-Medium.tff') format('ttf'),
+  src: url('/fonts/jost/Jost-500-Medium.ttf') format('ttf'),
     url('/fonts/jost/Jost-500-Medium.woff2') format('woff2');
   font-style: normal;
   font-display: swap;
@@ -270,7 +270,7 @@
 
 @font-face {
   font-family: 'Jost';
-  src: url('/fonts/jost/Jost-500-MediumItalic.tff') format('ttf'),
+  src: url('/fonts/jost/Jost-500-MediumItalic.ttf') format('ttf'),
     url('/fonts/jost/Jost-500-MediumItalic.woff2') format('woff2');
   font-style: italic;
   font-display: swap;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2288,7 +2288,7 @@
   resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
   integrity sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=
 
-"@mdx-js/mdx@^1.6.16":
+"@mdx-js/mdx@1.6.16", "@mdx-js/mdx@^1.6.16":
   version "1.6.16"
   resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-1.6.16.tgz#f01af0140539c1ce043d246259d8becd2153b2bb"
   integrity sha512-jnYyJ0aCafCIehn3GjYcibIapaLBgs3YkoenNQBPcPFyyuUty7B3B07OE+pMllhJ6YkWeP/R5Ax19x0nqTzgJw==
@@ -2340,7 +2340,7 @@
     unist-builder "2.0.3"
     unist-util-visit "2.0.3"
 
-"@mdx-js/react@^1.5.2", "@mdx-js/react@^1.6.14":
+"@mdx-js/react@1.6.16", "@mdx-js/react@^1.5.2", "@mdx-js/react@^1.6.14":
   version "1.6.16"
   resolved "https://registry.yarnpkg.com/@mdx-js/react/-/react-1.6.16.tgz#538eb14473194d0b3c54020cb230e426174315cd"
   integrity sha512-+FhuSVOPo7+4fZaRwWuCSRUcZkJOkZu0rfAbBKvoCg1LWb1Td8Vzi0DTLORdSvgWNbU6+EL40HIgwTOs00x2Jw==
@@ -2349,6 +2349,15 @@
   version "2.0.0-next.7"
   resolved "https://registry.yarnpkg.com/@mdx-js/react/-/react-2.0.0-next.7.tgz#33d3a2a961d5f2ebf36d096642c2a306111feae4"
   integrity sha512-VugV3o0zOD6pABtQEDDWNxiU8f+tS4KMiOgnwNiyxxOEwEZgBnXfMhZYDtHfrnhHxS59ValJ5zITnbdBwPbJkA==
+
+"@mdx-js/runtime@^1.6.14":
+  version "1.6.16"
+  resolved "https://registry.yarnpkg.com/@mdx-js/runtime/-/runtime-1.6.16.tgz#44166bcd2cc49831d1bb62e6c59509a4ec052650"
+  integrity sha512-gpDyzwd4tPpEZL3EHE+v+eqfFxVUhoioRwll0nLwLhXRzJah5ffsmGEhwbkhZjM7LOcr03IjfxN8GLFBZssbKw==
+  dependencies:
+    "@mdx-js/mdx" "1.6.16"
+    "@mdx-js/react" "1.6.16"
+    buble-jsx-only "^0.19.8"
 
 "@mdx-js/runtime@^2.0.0-next.4":
   version "2.0.0-next.7"


### PR DESCRIPTION
```
yarn run-script ./packages/print/src/index.tsx --file ~/work/matters/2c43fe5f-bfee-4c7c-a7c8-1f82161cee1b/writing/reply_to_motion_to_vacate.mdx
```

TODO: Add a MDX Runtime wrapper that maps **every** component to its
React-PDF counterpart.