### PR TITLE
add react-axe.

### DIFF
--- a/packages/interface/gatsby-config.js
+++ b/packages/interface/gatsby-config.js
@@ -80,6 +80,7 @@ module.exports = {
     'gatsby-plugin-react-helmet',
     'gatsby-plugin-offline',
     'gatsby-plugin-mdx',
+    'gatsby-plugin-react-axe',
     'gatsby-plugin-sitemap',
     {
       options: {

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -36,6 +36,7 @@
     "gatsby-plugin-sharp": "^2.6.27",
     "gatsby-plugin-sitemap": "^2.4.11",
     "gatsby-plugin-typescript": "^2.4.18",
+    "gatsby-plugin-react-axe": "0.5.0",
     "gatsby-remark-images": "^3.3.22",
     "gatsby-source-filesystem": "^2.3.23",
     "gatsby-source-graphql": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4628,7 +4628,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
   integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
 
-axe-core@^3.5.4:
+axe-core@^3.5.0, axe-core@^3.5.4:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.5.tgz#84315073b53fa3c0c51676c588d59da09a192227"
   integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
@@ -9410,6 +9410,13 @@ gatsby-plugin-page-creator@^2.3.22:
     graphql "^14.6.0"
     lodash "^4.17.15"
     slugify "^1.4.4"
+
+gatsby-plugin-react-axe@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-axe/-/gatsby-plugin-react-axe-0.5.0.tgz#22821af29b2bfbacd55041143d8e1815e3a83e95"
+  integrity sha512-l7bz7/0t/GnmER3WBoEjux39HNY/9+BYqC6TgpqkySW671RNVg6zmOAvVZ9qqMbeSeWY9U5AypHpdQAqkRpghw==
+  dependencies:
+    react-axe "^3.4.1"
 
 gatsby-plugin-react-helmet@^3.3.10:
   version "3.3.10"
@@ -16239,6 +16246,14 @@ react-animate-height@2.0.21:
     classnames "^2.2.5"
     prop-types "^15.6.1"
 
+react-axe@^3.4.1:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/react-axe/-/react-axe-3.5.3.tgz#38dac84e20cdf3e09e5752eb405b30c5ac845fa8"
+  integrity sha512-WDKAoLVsC6rsmYboXThY7OnVDaQOOOecySHJJjggn1cFOJyWtzNh2uiV3oSxoAolONGTi22G9zKDxw53g/8Vqg==
+  dependencies:
+    axe-core "^3.5.0"
+    requestidlecallback "^0.3.0"
+
 react-circular-progressbar@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/react-circular-progressbar/-/react-circular-progressbar-2.0.3.tgz#fa8eb59f8db168d2904bae4590641792c80f5991"
@@ -17803,6 +17818,11 @@ request@^2.83.0, request@^2.88.2:
     tough-cookie "~2.5.0"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
+
+requestidlecallback@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/requestidlecallback/-/requestidlecallback-0.3.0.tgz#6fb74e0733f90df3faa4838f9f6a2a5f9b742ac5"
+  integrity sha1-b7dOBzP5DfP6pIOPn2oqX5t0KsU=
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
This Pr adds `react-axe` as I think it is worth adding in https://github.com/NeonLaw/codebase/pull/739#pullrequestreview-477883384

> I think it would be also worth add react-axe as well https://github.com/dequelabs/react-axe a library that Tests React applications with the axe-core accessibility testing library. Results will show in the Chrome DevTools console.
> We do have injectAxe in the accessibility specs but that requires the test suite to run for the inspections. Catching the problems upfront while we are making the changes would be way nicer.


This is it looks in action.


![image](https://user-images.githubusercontent.com/46004116/91594178-e37b1e00-e97a-11ea-9651-81fb4ed7e925.png)
