### PR TITLE
[pgp]: add copy to clipboard functionality.

### DIFF
--- a/packages/interface/cypress/integration/pgp.spec.ts
+++ b/packages/interface/cypress/integration/pgp.spec.ts
@@ -1,0 +1,13 @@
+/* eslint-disable no-undef */
+
+// This spec is in-complete as currently there is no way to call
+// the paste command in cypress.
+// See: https://github.com/cypress-io/cypress/issues/2851
+
+describe('PGP Key', () => {
+  it('Copy to Clipboard button copies the PGP Key to the clipboard.', () => {
+    cy.visit('/pgp');
+    cy.contains('Copy to Clipboard');
+    cy.get('button[aria-label="Copy PGP Key to Clip Board"]').click();
+  });
+});

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@apollo/client": "3.1.4",
     "@auth0/auth0-spa-js": "^1.11.0",
-    "@chakra-ui/core": "1.0.0-rc.3", 
+    "@chakra-ui/core": "1.0.0-rc.3",
     "@chakra-ui/icons": "1.0.0-rc.3",
     "@hookform/error-message": "^0.0.4",
     "@mdx-js/mdx": "^1.6.16",
@@ -17,6 +17,7 @@
     "@reach/router": "^1.3.4",
     "apollo-boost": "^0.4.9",
     "apollo-link-context": "^1.0.20",
+    "clipboard-copy": "^3.1.0",
     "eslint-plugin-jsdoc": "^30.3.1",
     "gatsby": "2.24.53",
     "gatsby-image": "^2.4.16",

--- a/packages/interface/src/components/pgp-key.tsx
+++ b/packages/interface/src/components/pgp-key.tsx
@@ -1,0 +1,41 @@
+import { Box, Tooltip } from '@chakra-ui/core';
+import React, { useRef, useState } from 'react';
+
+import { Button } from '@neonlaw/shared-ui/src/components/button';
+import copy from 'clipboard-copy';
+import { gutters } from '@neonlaw/shared-ui/src/themes/neonLaw';
+
+export const PGPKey = ({ children }) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const keyContainerRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <Box overflowX="scroll">
+      <Button
+        aria-label="Copy PGP Key to Clip Board"
+        marginTop={gutters.small}
+        onClick={() => {
+          keyContainerRef.current
+            ? copy(keyContainerRef.current.textContent || '')
+            : null;
+          setIsOpen(true);
+        }}
+        onMouseLeave={() => {
+          setIsOpen(false);
+        }}
+      >
+        <Tooltip
+          label="Copied to Clipboard"
+          isOpen={isOpen}
+          placement="top"
+          aria-label="Copied to Clipboard"
+          hasArrow={true}
+          transform={'translateY(-.5rem)'}
+        >
+          Copy to Clipboard
+        </Tooltip>
+      </Button>
+      <div ref={keyContainerRef}>{children}</div>
+    </Box>
+  );
+};

--- a/packages/interface/src/content/pgp.mdx
+++ b/packages/interface/src/content/pgp.mdx
@@ -1,13 +1,21 @@
 ---
 title: PGP Key
 slug: /pgp
-updatedAt: "2020-07-31"
+updatedAt: '2020-07-31'
 tags: legal,privacy
 ---
+
+import { PGPKey } from '../components/pgp-key';
+import { Box } from '@chakra-ui/core';
+import { sizes } from '@neonlaw/shared-ui/src/themes/neonLaw';
+
+<Box maxW={sizes.textContainerMedium}>
 
 If you have something you'd like to send us via PGP encryption, please
 encrypt your message with this following public key. You can then email us at
 support@neonlaw.com with the message, or contact us.
+
+<PGPKey>
 
 ```
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -63,3 +71,7 @@ u24VSNuZ34XE
 =NvHM
 -----END PGP PUBLIC KEY BLOCK-----
 ```
+
+</PGPKey>
+
+</Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6587,6 +6587,11 @@ cli-width@^3.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
+clipboard-copy@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/clipboard-copy/-/clipboard-copy-3.1.0.tgz#4c59030a43d4988990564a664baeafba99f78ca4"
+  integrity sha512-Xsu1NddBXB89IUauda5BIq3Zq73UWkjkaQlPQbLNvNsd5WBMnTWPNKYR6HGaySOxGYZ+BKxP2E9X4ElnI3yiPA==
+
 clipboardy@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-2.3.0.tgz#3c2903650c68e46a91b388985bc2774287dba290"


### PR DESCRIPTION
Fixes #758 

This is how it looks: 

![image](https://user-images.githubusercontent.com/46004116/92355411-9840d800-f0fd-11ea-9603-679018f440f9.png)

I have added a spec which is incomplete because currently there is no way of testing whether something is being copied to the clipboard or replicating the browsers paste command in cypress.

I tried to hack my way around by adding an input element to the document and then typing in the key into it via `.type('{ctrl}v')` so that what's in the clipboard can be pasted into the input and the later on which can be compared i.e whether it equals the key value or not.

https://github.com/cypress-io/cypress/issues/2851
https://github.com/cypress-io/cypress/issues/2386
