### PR TITLE
Revert CSP Changes

### DIFF
--- a/packages/interface/gatsby-config.js
+++ b/packages/interface/gatsby-config.js
@@ -22,7 +22,26 @@ module.exports = {
       },
       resolve: 'gatsby-plugin-intl',
     },
-    'gatsby-plugin-csp',
+    {
+      options: {
+        directives: {
+          'connect-src': '* data: blob: \'unsafe-inline\'',
+          'default-src': '*  data: blob: filesystem: about: ' +
+            'ws: wss: \'unsafe-inline\' \'unsafe-eval\'',
+          'font-src': '* data: blob: \'unsafe-inline\'',
+          'frame-src': '* data: blob: \'unsafe-inline\';',
+          'img-src': '* data: blob: \'unsafe-inline\'',
+          'script-src': '* \'unsafe-eval\' \'unsafe-inline\'',
+          'style-src': '* data: blob: \'unsafe-inline\'',
+        },
+        disableOnDev: true,
+        mergeDefaultDirectives: true,
+        mergeScriptHashes: true,
+        mergeStyleHashes: false,
+        reportOnly: false,
+      },
+      resolve: 'gatsby-plugin-csp',
+    },
     'gatsby-plugin-sharp',
     'gatsby-transformer-sharp',
     {


### PR DESCRIPTION
The default CSP for the gatsby-plugin-csp is too restrictive. This PR
allows for `unsafe-inline` to be enabled. We should turn this off
someday.

Fixes #810