### PR TITLE
Staging GitHub workflow

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -5,9 +5,10 @@ on:
   pull_request:
     branches:
       - development
-  # Deploy production from development every day at 12:00 pm UTC
+
+  # Deploy production from development at 4:00 am PST, Monday through Thursday
   schedule:
-    - cron: "0 12 * * *"
+    - cron: "0 12 * * MON-THU"
 
 jobs:
   deploy_interface_production:

--- a/.github/workflows/public_docker_images.yml
+++ b/.github/workflows/public_docker_images.yml
@@ -2,9 +2,13 @@
 name: public_docker_images
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - continuous_integration
     branches:
       - development
+    types:
+      - completed
   pull_request:
     branches:
       - development

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -9,6 +9,9 @@ on:
       - development
     types:
       - completed
+  pull_request:
+    branches:
+      - development
 
 jobs:
   deploy_neon_law_staging:

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -2,12 +2,13 @@
 name: staging
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - continuous_integration
     branches:
       - development
-  pull_request:
-    branches:
-      - development
+    types:
+      - completed
 
 jobs:
   deploy_neon_law_staging:


### PR DESCRIPTION
This commit only runs the `staging` and `public_docker_images` workflows after the workflow
`continous_integration` is successful on the `development` branch.