### PR TITLE
Add workflow dispatch trigger for production GitHub Action

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: "0 12 * * MON-THU"
 
+  workflow_dispatch:
+    tags:
+      description: Manual production release
+
 jobs:
   deploy_interface_production:
     runs-on: ubuntu-latest

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -8,7 +8,7 @@ on:
 
   # Deploy production from development at 4:00 am PST, Monday through Thursday
   schedule:
-    - cron: "0 12 * * MON-THU"
+    - cron: "0 12 * * 1-4"
 
   workflow_dispatch:
 

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -11,8 +11,6 @@ on:
     - cron: "0 12 * * MON-THU"
 
   workflow_dispatch:
-    tags:
-      description: Manual production release
 
 jobs:
   deploy_interface_production:


### PR DESCRIPTION
This should allow for manual dispatches of the `production` branch for ad hoc deploys.