### PR TITLE
support CMD+Enter instead of Shift+Enter when submitting a form on Apple devices.

### DIFF
--- a/packages/shared-ui/src/components/modals/createFlashcardModal.tsx
+++ b/packages/shared-ui/src/components/modals/createFlashcardModal.tsx
@@ -14,13 +14,14 @@ import {
 import React, { useEffect, useRef, useState } from 'react';
 import { StringInput, Textarea } from '../../forms/base';
 import { colors, gutters } from '../../themes/neonLaw';
+import { submitOnMetaEnter, submitOnShiftEnter } from '../../utils/keyboard';
 
 import { SubmissionInProgress } from '../submission-in-progress';
 import { gql } from '@apollo/client';
-import { submitOnShiftEnter } from '../../utils/keyboard';
 import { useCreateFlashcardMutation } from '../../utils/api';
 import { useForm } from 'react-hook-form';
 import { useIntl } from 'gatsby-plugin-intl';
+import { useOS } from '../../utils/useOS';
 
 export const CreateFlashcardModal = ({ isOpen, onClose, onOpen }) => {
   const intl = useIntl();
@@ -53,6 +54,7 @@ export const CreateFlashcardModal = ({ isOpen, onClose, onOpen }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [formError, setFormError] = useState('');
   const formRef = useRef<HTMLFormElement>(null);
+  const OS = useOS();
 
   const onSubmit = async ({ answer, prompt }) => {
     await createFlashcard({ variables: { answer, prompt } })
@@ -71,7 +73,11 @@ export const CreateFlashcardModal = ({ isOpen, onClose, onOpen }) => {
   };
 
   const keyDownHandler = (e: any) => {
-    submitOnShiftEnter(e, formRef);
+    if (OS === 'Mac OS') {
+      submitOnMetaEnter(e, formRef);
+    } else {
+      submitOnShiftEnter(e, formRef);
+    }
   };
 
   const handleCPress = (e) => {

--- a/packages/shared-ui/src/components/modals/createFlashcardModal.tsx
+++ b/packages/shared-ui/src/components/modals/createFlashcardModal.tsx
@@ -21,8 +21,8 @@ import { gql } from '@apollo/client';
 import { useCreateFlashcardMutation } from '../../utils/api';
 import { useForm } from 'react-hook-form';
 import { useIntl } from 'gatsby-plugin-intl';
-import { useOS } from '../../utils/useOS';
 import { useKeyPressed } from '../../utils/useKeyPressed';
+import { useOS } from '../../utils/useOS';
 
 export const CreateFlashcardModal = ({ isOpen, onClose, onOpen }) => {
   const intl = useIntl();

--- a/packages/shared-ui/src/components/modals/updateFlashcardModal.tsx
+++ b/packages/shared-ui/src/components/modals/updateFlashcardModal.tsx
@@ -14,6 +14,7 @@ import {
 import React, { useEffect, useRef, useState } from 'react';
 import { StringInput, Textarea } from '../../forms/base';
 import { colors, gutters } from '../../themes/neonLaw';
+import { submitOnMetaEnter, submitOnShiftEnter } from '../../utils/keyboard';
 import {
   useDeleteFlashcardByIdMutation,
   useUpdateFlashcardByIdMutation,
@@ -21,9 +22,9 @@ import {
 
 import { SubmissionInProgress } from '../submission-in-progress';
 import styled from '@emotion/styled';
-import { submitOnShiftEnter } from '../../utils/keyboard';
 import { useForm } from 'react-hook-form';
 import { useIntl } from 'gatsby-plugin-intl';
+import { useOS } from '../../utils/useOS';
 
 interface UpdateFlashcardModalProps {
   isOpen: boolean;
@@ -73,6 +74,7 @@ export const UpdateFlashcardModal = ({
   const [focus, setFocus] = useState(false);
   const [formError, setFormError] = useState('');
   const formRef = useRef<HTMLFormElement>(null);
+  const OS = useOS();
 
   const onSubmit = async ({ answer, prompt }) => {
     await updateFlashcard({
@@ -93,7 +95,11 @@ export const UpdateFlashcardModal = ({
   };
 
   const keyDownHandler = (e: any) => {
-    submitOnShiftEnter(e, formRef);
+    if (OS === 'Mac OS') {
+      submitOnMetaEnter(e, formRef);
+    } else {
+      submitOnShiftEnter(e, formRef);
+    }
   };
 
   const handleDPress = async (e) => {
@@ -104,7 +110,7 @@ export const UpdateFlashcardModal = ({
 
   const deleteFlashcard = async () => {
     const confirmDelete = confirm(
-      'Are you sure you want to delete the flashcard?'
+      'Are you sure you want to delete the flashcard?',
     );
 
     if (confirmDelete) {

--- a/packages/shared-ui/src/utils/keyboard.ts
+++ b/packages/shared-ui/src/utils/keyboard.ts
@@ -1,10 +1,20 @@
+const submit = (e: any, ref: any) => {
+  const form = ref.current;
+  e.preventDefault();
+  if (null !== form) {
+    form.dispatchEvent(new Event('submit', { cancelable: true }));
+  }
+};
+
 export const submitOnShiftEnter = (e: any, ref: any) => {
   if (isShiftEnterPressed(e)) {
-    const form = ref.current;
-    e.preventDefault();
-    if (null !== form) {
-      form.dispatchEvent(new Event('submit', { cancelable: true }));
-    }
+    submit(e, ref);
+  }
+};
+
+export const submitOnMetaEnter = (e: any, ref: any) => {
+  if (isCommandEnterPressed(e)) {
+    submit(e, ref);
   }
 };
 


### PR DESCRIPTION
Fixes #901 