### PR TITLE
use e.key instead of e.keyCode( as it is deprecated).

### DIFF
--- a/packages/interface/cypress/integration/keyboard-shortcuts-modal.spec.ts
+++ b/packages/interface/cypress/integration/keyboard-shortcuts-modal.spec.ts
@@ -4,7 +4,7 @@ describe('Keyboard shortcuts modal', () => {
   it('renders the Keyboard shortcuts modal', () => {
     cy.visit('/');
     cy.wait(2000);
-    cy.get('input').type('{shift}/');
+    cy.get('input').type('?');
     cy.get('.chakra-modal__header').contains('Keyboard Shortcuts');
   });
   it('closes the shortcut modal when the overlay is being clicked.', () => {

--- a/packages/shared-ui/src/components/flashcardContainer.tsx
+++ b/packages/shared-ui/src/components/flashcardContainer.tsx
@@ -32,8 +32,7 @@ export const FlashcardContainer = () => {
       if (isTextAreaFocused) {
         return;
       }
-      // keyCode 37 is the left arrow
-      if (event.keyCode === 37) {
+      if (event.key === 'ArrowLeft') {
         if (selectedFlashcard === 0) {
           return changeSelectedFlashcard(flashcards.length - 1);
         }
@@ -41,8 +40,7 @@ export const FlashcardContainer = () => {
           return changeSelectedFlashcard(selectedFlashcard - 1);
         }
       }
-      // keyCode 39 is the right arrow
-      if (event.keyCode === 39) {
+      if (event.key === 'ArrowRight') {
         if (selectedFlashcard === flashcards.length - 1) {
           return changeSelectedFlashcard(0);
         }

--- a/packages/shared-ui/src/components/shortcuts-modal.tsx
+++ b/packages/shared-ui/src/components/shortcuts-modal.tsx
@@ -64,7 +64,7 @@ const ShortcutsModal = () => {
   const { colorMode } = useColorMode();
 
   const handleOpenModal = (e: any) => {
-    if (e.shiftKey && e.keyCode == 191) {
+    if (e.key == '?') {
       // detect Shift + / i.e '?'
       onOpen();
     }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode

![image](https://user-images.githubusercontent.com/46004116/95026115-6f821300-06a8-11eb-9cf9-7310137734db.png)
