### PR TITLE
upgrade VM to e2-standard-2

### DIFF
--- a/infrastructure/modules/google_container_cluster/main.tf
+++ b/infrastructure/modules/google_container_cluster/main.tf
@@ -43,7 +43,7 @@ resource "google_container_node_pool" "primary" {
 
   node_config {
     preemptible  = true
-    machine_type = "e2-standard-2"
+    machine_type = "e2-standard-4"
 
     metadata = {
       disable-legacy-endpoints = "true"


### PR DESCRIPTION
These are cheaper pre-emptible VMs which means they can be shut off at
anytime but they're 10x cheaper than anything else on GKE