### PR TITLE
Add Service Account IAM binding

### DIFF
--- a/infrastructure/gcp/main.tf
+++ b/infrastructure/gcp/main.tf
@@ -84,10 +84,6 @@ module "company_bucket" {
   ]
 }
 
-module "transloadit_user" {
-  source     = "./modules/transloadit_user"
-}
-
 module "application_user" {
   source     = "./modules/application_user"
 }

--- a/infrastructure/gcp/modules/application_user/main.tf
+++ b/infrastructure/gcp/modules/application_user/main.tf
@@ -7,3 +7,12 @@ resource "google_service_account" "application_user_account" {
 resource "google_service_account_key" "application_user_account_key" {
   service_account_id = google_service_account.application_user_account.name
 }
+
+resource "google_service_account_iam_binding" "nick_iam_binding" {
+  service_account_id = google_service_account.application_user_account.name
+  role               = "roles/iam.serviceAccountUser"
+
+  members = [
+    "user:nick@neonlaw.com",
+  ]
+}

--- a/infrastructure/gcp/modules/transloadit_user/main.tf
+++ b/infrastructure/gcp/modules/transloadit_user/main.tf
@@ -1,9 +1,0 @@
-resource "google_service_account" "user_account" {
-  account_id   = "transloadit-user"
-  display_name = "Transloadit User"
-  description  = "GCP Credentials used for Transloadit"
-}
-
-resource "google_service_account_key" "user_account_key" {
-  service_account_id = google_service_account.user_account.name
-}

--- a/infrastructure/gcp/modules/transloadit_user/outputs.tf
+++ b/infrastructure/gcp/modules/transloadit_user/outputs.tf
@@ -1,3 +1,0 @@
-output "account_key" {
-  value = google_service_account_key.user_account_key.private_key
-}

--- a/infrastructure/gcp/modules/write_only_bucket/main.tf
+++ b/infrastructure/gcp/modules/write_only_bucket/main.tf
@@ -18,15 +18,16 @@ resource "google_storage_bucket" "write_only_bucket" {
 }
 
 resource "google_service_account" "write_only_bucket_user_account" {
-  account_id   = "upload-bucket-user"
-  display_name = "Write Only Access User"
+  account_id   = "upload-bucket-service-account"
+  display_name = "Service account for writing to the Upload bucket"
+  description  = "A service account with write-only permissions to the upload bucket"
 }
 
 resource "google_service_account_key" "write_only_bucket_user_account_key" {
   service_account_id = google_service_account.write_only_bucket_user_account.name
 }
 
-resource "google_service_account_iam_binding" "admin-account-iam" {
+resource "google_service_account_iam_binding" "nick_iam_binding" {
   service_account_id = google_service_account.write_only_bucket_user_account.name
   role               = "roles/iam.serviceAccountUser"
 

--- a/infrastructure/gcp/modules/write_only_bucket/main.tf
+++ b/infrastructure/gcp/modules/write_only_bucket/main.tf
@@ -25,3 +25,12 @@ resource "google_service_account" "write_only_bucket_user_account" {
 resource "google_service_account_key" "write_only_bucket_user_account_key" {
   service_account_id = google_service_account.write_only_bucket_user_account.name
 }
+
+resource "google_service_account_iam_binding" "admin-account-iam" {
+  service_account_id = google_service_account.write_only_bucket_user_account.name
+  role               = "roles/iam.serviceAccountUser"
+
+  members = [
+    "user:nick@neonlaw.com",
+  ]
+}

--- a/infrastructure/gcp/outputs.tf
+++ b/infrastructure/gcp/outputs.tf
@@ -73,8 +73,3 @@ output "application_user_account_key" {
 output "database_name" {
   value = "neon-law"
 }
-
-output "transloadit_user_account_key" {
-  value = module.transloadit_user.account_key
-  sensitive = true
-}


### PR DESCRIPTION
This adds nick@neonlaw.com to the service accounts created and deletes
the transloadit TF module in favor of the service account created in the
write_only_bucket.