### PR TITLE
Turn off uniform bucket policy for upload bucket

### DIFF
--- a/infrastructure/gcp/modules/write_only_bucket/main.tf
+++ b/infrastructure/gcp/modules/write_only_bucket/main.tf
@@ -3,7 +3,7 @@ resource "google_storage_bucket" "write_only_bucket" {
   location      = "US"
   force_destroy = true
 
-  uniform_bucket_level_access = true
+  uniform_bucket_level_access = false
 
   versioning {
     enabled = true


### PR DESCRIPTION
Transloadit sets separate ACLs for bucket uploads so this PR turns off
uniform bucket access so they can now do so.