### PR TITLE
make the dashboard compatible with dark more + correct the search input theme

### DIFF
--- a/packages/interface/src/components/navigationBars/baseNavigationBar.tsx
+++ b/packages/interface/src/components/navigationBars/baseNavigationBar.tsx
@@ -14,6 +14,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/core';
 import React, { useState } from 'react';
+
 import { AuthenticatedDropdown } from './authenticatedDropdown';
 import { AuthenticationContext } from '../../utils/authenticationContext';
 import { BlackLivesMatter } from './blackLivesMatter';
@@ -72,7 +73,9 @@ export const BaseNavigationBar = ({
 
             <Search
               version="desktop"
+              hideOnMobile={true}
               isRenderedOnDashboard={false}
+              background={colors.background.dark}
             />
 
             <Flex flexGrow={1} align="center" justify="flex-end">

--- a/packages/interface/src/components/navigationBars/portalNavigationBar.tsx
+++ b/packages/interface/src/components/navigationBars/portalNavigationBar.tsx
@@ -10,10 +10,11 @@ import {
   MenuButton,
   MenuItem,
   MenuList,
+  useColorModeValue,
   useDisclosure,
 } from '@chakra-ui/core';
 import React, { useState } from 'react';
-import { colors, gutters } from '../../themes/neonLaw';
+import { colors, gutters, theme } from '../../themes/neonLaw';
 
 import { AuthenticatedDropdown } from './authenticatedDropdown';
 import { AuthenticationContext } from '../../utils/authenticationContext';
@@ -45,21 +46,27 @@ export const PortalNavigationBar = ({
     <>
       <Box
         top="2em"
-        position='inherit'
+        position="inherit"
         padding={`${gutters.xSmallOne} ${gutters.xSmall}`}
         zIndex={4}
-        bg='#f4f4f4'
-        color='black'
+        bg={useColorModeValue(theme.colors.gray[100], theme.colors.black)}
+        borderBottom={useColorModeValue('', '1px solid #222')}
+        color="black"
         left="0"
         right="0"
         width="full"
-        height='auto'
+        height="auto"
       >
         <Container isFullBleed={true}>
           <Flex boxSize="100%" align="center">
             <Search
               version="desktop"
               isRenderedOnDashboard={true}
+              background={useColorModeValue(
+                colors.background.light,
+                colors.background.dark,
+              )}
+              borderColor={useColorModeValue(theme.colors.gray[300], '')}
             />
 
             <Flex flexGrow={1} align="center" justify="flex-end">
@@ -84,13 +91,15 @@ export const PortalNavigationBar = ({
                       right: '100%',
                       transition: 'all 0.4s cubic-bezier(0, 0.5, 0, 1)',
                     }}
-                    _hover={{
-                      '&:after': {
-                        background: colors.primaryColor400,
-                        right: 0,
-                      },
-                      color: colors.primaryColor400,
-                    } as any}
+                    _hover={
+                      {
+                        '&:after': {
+                          background: colors.primaryColor400,
+                          right: 0,
+                        },
+                        color: colors.primaryColor400,
+                      } as any
+                    }
                     activeClassName="nav-link--active"
                   >
                     {link.label}

--- a/packages/interface/src/components/navigationBars/search.tsx
+++ b/packages/interface/src/components/navigationBars/search.tsx
@@ -7,14 +7,13 @@ import styled from '@emotion/styled';
 
 const StyledInput = styled(Input)<{
   version: 'desktop' | 'mobile';
-  dashboard?: string;
+  hideOnMobile?: boolean;
 }>`
   max-width: 350px;
-  border: 1px solid ${colors.inputBorders.light};
 
   @media (max-width: 560px) {
-    display: ${({ version, dashboard }) =>
-    version === 'desktop' && dashboard === 'true' ? 'inherit' : 'none'};
+    display: ${({ hideOnMobile }) =>
+    hideOnMobile ? 'none' : 'inherit'};
     max-width: 240px;
   }
 
@@ -26,10 +25,17 @@ const StyledInput = styled(Input)<{
 interface SearchProps {
   version: 'desktop' | 'mobile';
   isRenderedOnDashboard?: boolean;
+  hideOnMobile?: boolean;
+  background?: string;
+  borderColor?: string;
 }
 
 export const Search = ({
-  version, isRenderedOnDashboard
+  version,
+  isRenderedOnDashboard,
+  background,
+  borderColor,
+  hideOnMobile
 }: SearchProps): JSX.Element => {
   const inputRef = useRef<any>();
 
@@ -65,16 +71,12 @@ export const Search = ({
           styles={css`
             .search-input {
               background: ${colors.background.dark} !important;
-              border-color: ${theme.colors.gray[700]} !important;
-              &::placeholder {
-                color: inherit;
-              }
             }
           `}
         />
       ) : null}
       <StyledInput
-        dashboard={isRenderedOnDashboard ? 'true' : 'false'}
+        hideOnMobile={hideOnMobile}
         className={!isRenderedOnDashboard ? 'search-input' : ''}
         version={version}
         ref={inputRef}
@@ -84,12 +86,14 @@ export const Search = ({
         background={
           version === 'mobile'
             ? `${colors.background[colorMode]} !important`
-            : ''
+            : background
+              ? background
+              : ''
         }
         borderColor={
           version === 'mobile'
             ? `${colors.inputBorders[colorMode]} !important`
-            : ''
+            : borderColor ? borderColor : theme.colors.gray[700]
         }
       />
     </>

--- a/packages/interface/src/components/sideNavigation/sideNavContent.tsx
+++ b/packages/interface/src/components/sideNavigation/sideNavContent.tsx
@@ -68,7 +68,7 @@ const StyledSideNavContent = styled.div<{ isRenderedOnDashboard?: boolean }>`
         border-bottom: 2px solid transparent;
       }
 
-      @media(max-width: 640px) {
+      @media (max-width: 640px) {
         margin: 0;
       }
 
@@ -90,7 +90,6 @@ const StyledSideNavContent = styled.div<{ isRenderedOnDashboard?: boolean }>`
     svg {
       display: inline-block;
       margin-right: ${gutters.xSmallOne};
-
 
       @media (max-width: 800px) {
         margin-right: 0;
@@ -151,25 +150,28 @@ export const SideNavContent = ({
             <img className="logo" src="/images/logo.svg" alt="Neon Law" />
           </Box>
           <Box mb="10" display={isRenderedOnDashboard ? 'none' : ''}>
-            <Search version="mobile" />
+            <Search
+              version="mobile"
+            />
           </Box>
           <div className="links">
-            {links.map((link, i) => (
-              !link ? null : <Box key={i}>
-                <Link
-                  activeStyle={{ color: activeColor[colorMode] }}
-                  activeClassName="active"
-                  to={link.route}
-                  className="link"
-                  data-testId={
-                    `${link.label.toLowerCase()}-side-navigation-link`
-                  }
-                >
-                  {isRenderedOnDashboard ? link.icon : null}
-                  {link.label}
-                </Link>
-              </Box>
-            ))}
+            {links.map((link, i) =>
+              !link ? null : (
+                <Box key={i}>
+                  <Link
+                    activeStyle={{ color: activeColor[colorMode] }}
+                    activeClassName="active"
+                    to={link.route}
+                    className="link"
+                    // eslint-disable-next-line
+                    data-testId={`${link.label.toLowerCase()}-side-navigation-link`}
+                  >
+                    {isRenderedOnDashboard ? link.icon : null}
+                    {link.label}
+                  </Link>
+                </Box>
+              ),
+            )}
             <AuthenticationContext.Consumer>
               {({ isLoading, isAuthenticated, login }) => {
                 if (isLoading || isAuthenticated) {

--- a/packages/interface/src/layouts/portalLayout.tsx
+++ b/packages/interface/src/layouts/portalLayout.tsx
@@ -1,4 +1,5 @@
-import { gutters, theme } from '../themes/neonLaw';
+import { colors, gutters, theme } from '../themes/neonLaw';
+
 import { ApolloProvider } from '@apollo/client';
 import { AuthenticationContext } from '../utils/authenticationContext';
 import { LoadingPage } from '../components/loadingPage';
@@ -83,7 +84,8 @@ export const PortalLayout = ({ children }) => {
         }
         return (
           <ApolloProvider client={apolloClient}>
-            <StyledPortalLayout>
+            <StyledPortalLayout
+            >
               <div className="wrapper">
                 <Aside>
                   <PortalSideNavigation />
@@ -92,8 +94,9 @@ export const PortalLayout = ({ children }) => {
                   style={{
                     background:
                       colorMode === 'dark'
-                        ? theme.colors.black
+                        ? '#111'
                         : theme.colors.white,
+                    color: colors.text[colorMode]
                   }}
                 >
                   <PortalNavigationBar isRenderedOnDashboard={true} />


### PR DESCRIPTION
This Pr makes the Dashboard compatible with the dark mode with these changes in place this is how it is gonna look:


![image](https://user-images.githubusercontent.com/46004116/103327894-5f47bd00-4a78-11eb-881a-787c53a02235.png)

This is how it looked before the text and other contents were not well readable:

![image](https://user-images.githubusercontent.com/46004116/103327919-7f777c00-4a78-11eb-825d-98b71185fc38.png)

Also, the white input on the dark nav of the site didn't look good so I reverted it back to the dark background:

### Before

 ![image](https://user-images.githubusercontent.com/46004116/103327971-b64d9200-4a78-11eb-9fd9-a44f00f984f0.png) 

### After
![image](https://user-images.githubusercontent.com/46004116/103328016-e5640380-4a78-11eb-8f53-6e44ad474988.png)
