### PR TITLE
remove documentable table ID

### DIFF
--- a/packages/server/migrations/committed/000069.sql
+++ b/packages/server/migrations/committed/000069.sql
@@ -1,0 +1,9 @@
+--! Previous: sha1:1b1aed9f8753d0758e524dfee1189f8dc778bd6e
+--! Hash: sha1:753ee70cf029eb97cd1c2d6fbce14dfc1dc330f2
+
+-- Enter migration here
+
+
+DROP INDEX IF EXISTS document_documentable_association;
+
+ALTER TABLE document DROP COLUMN IF EXISTS documentable_table_id;


### PR DESCRIPTION
In the same transaction, a Document should be created first, then either
a response or matter document. By removing this column we are allowing
for a Document to be created first, instead of what was previously a
stalemate because one foreign key had to exist before the other.