### PR TITLE
Simpler port forwarding for Neo4j

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,20 @@ With either command (both cannot be ran at the same time), you'll have a
 PostgreSQL database running at `127.0.0.1:5432`, which you can then connect to
 with the GCP SQL credentials for staging and production.
 
+## Neo4j Proxy
+
+If you need to access either the staging or production neo4j on your local
+machine, you can connect to it via GKE Service Port forwarding. You can
+connect to `staging` and `production` with these respective commands:
+
+```
+yarn run neo4j-proxy-staging
+yarn run neo4j-proxy-production
+```
+
+With either command (both cannot be ran at the same time), you'll have a
+local Neo4j instance at `127.0.0.1:7474`, which you can then connect to with
+the GCP SQL credentials for staging and production.
 ### Getting KubeConfig on your machine
 
 ```bash

--- a/infrastructure/modules/kubernetes_ingress/main.tf
+++ b/infrastructure/modules/kubernetes_ingress/main.tf
@@ -29,20 +29,6 @@ resource "kubernetes_ingress" "primary" {
     }
 
     rule {
-      host = var.environment == "production" ? "www.neonlaw.com" : "www.neonlaw.net"
-      http {
-        path {
-          backend {
-            service_name = "${var.environment}-neo4j-neo4j"
-            service_port = 7474
-          }
-
-          path = "/browser/*"
-        }
-      }
-    }
-
-    rule {
       host = var.environment == "production" ? "www.lawjobresources.com" : "www.lawjobresources.info"
       http {
         path {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
         "run-script": "ts-node --transpile-only",
         "sql-proxy-staging": "docker run -v $(pwd)/neon-law-staging.credentials.json:/config -p 127.0.0.1:5432:5432 gcr.io/cloudsql-docker/gce-proxy:1.17 /cloud_sql_proxy -instances=neon-law-staging:us-west4:neon-law=tcp:0.0.0.0:5432 -credential_file=/config",
         "sql-proxy-production": "docker run -v $(pwd)/neon-law-production.credentials.json:/config -p 127.0.0.1:5432:5432 gcr.io/cloudsql-docker/gce-proxy:1.17 /cloud_sql_proxy -instances=neon-law-production:us-west4:neon-law=tcp:0.0.0.0:5432 -credential_file=/config",
+        "neo4j-proxy-production": "gcloud container clusters get-credentials neon-law-production --region us-west4 --project neon-law-production && kubectl port-forward $(kubectl get pod --selector=\"app.kubernetes.io/component=core,app.kubernetes.io/instance=production-neo4j,app.kubernetes.io/name=neo4j\" --output jsonpath='{.items[0].metadata.name}') 7474:7474",
+        "neo4j-proxy-staging": "gcloud container clusters get-credentials neon-law-staging --region us-west4 --project neon-law-staging && kubectl port-forward $(kubectl get pod --selector=\"app.kubernetes.io/component=core,app.kubernetes.io/instance=staging-neo4j,app.kubernetes.io/name=neo4j\" --output jsonpath='{.items[0].metadata.name}') 7474:7474",
         "test": "jest --forceExit --detectOpenHandles --coverage --coverageProvider=v8"
     },
     "dependencies": {


### PR DESCRIPTION
With port forwarding, we can access neo4j's browser on our local machine
using GKE credentials. Please refer to the changes in the `./README.md` file
for more info.