### PR TITLE
[practice-areas]: adjust the height of the cards.

### DIFF
--- a/packages/interface/src/components/desktopHalfMobileFullCard.tsx
+++ b/packages/interface/src/components/desktopHalfMobileFullCard.tsx
@@ -13,18 +13,20 @@ export const DesktopHalfMobileFullCard = ({ children, to }) => {
   return (
     <Box
       flex={['0 0 100%', '0 0 100%', '0 0 100%', '0 48%']}
+      maxWidth="600px"
       cursor={to ? 'pointer' : null}
       as={to ? Link : null}
       to={to ? to : null}
       className="outline-bordered"
+      margin={['1em 0', '1em 0', '2em 0']}
     >
       <Box
         borderWidth="1px"
         overflow="hidden"
-        margin={['1em 0', '1em 0', '2em 0']}
         background={colors.background[colorMode]}
         borderColor={colors.borders[colorMode]}
         boxShadow={shadows.light2}
+        height="100%"
       >
         {children}
       </Box>


### PR DESCRIPTION
fixes #1479

This is how the cards look at device width 1235px

![image](https://user-images.githubusercontent.com/46004116/105082737-d1c71e00-5ab5-11eb-9705-d16618f46973.png)
