### PR TITLE
Add relationship query for Neo4j

### DIFF
--- a/packages/interface/src/utils/api.tsx
+++ b/packages/interface/src/utils/api.tsx
@@ -489,6 +489,33 @@ export type CreateQuestionPayloadQuestionEdgeArgs = {
   orderBy?: Maybe<Array<QuestionsOrderBy>>;
 };
 
+/** All input for the `createRelationship` mutation. */
+export type CreateRelationshipInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  relationship?: Maybe<Scalars['String']>;
+  fromId?: Maybe<Scalars['UUID']>;
+  fromType?: Maybe<Scalars['String']>;
+  toId?: Maybe<Scalars['UUID']>;
+  toType?: Maybe<Scalars['String']>;
+};
+
+/** The output of our `createRelationship` mutation. */
+export type CreateRelationshipPayload = {
+  __typename?: 'CreateRelationshipPayload';
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  string?: Maybe<Scalars['String']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+};
+
 /** All input for the create `Response` mutation. */
 export type CreateResponseInput = {
   /**
@@ -1920,6 +1947,7 @@ export type Mutation = {
   deleteResponseDocumentById?: Maybe<DeleteResponseDocumentPayload>;
   createMatterDocumentFromUploadUrl?: Maybe<CreateMatterDocumentFromUploadUrlPayload>;
   createPrimaryKeyIdIfNotExists?: Maybe<CreatePrimaryKeyIdIfNotExistsPayload>;
+  createRelationship?: Maybe<CreateRelationshipPayload>;
   createRoleIfNotExists?: Maybe<CreateRoleIfNotExistsPayload>;
   updateQuestionnaireFromNeo4J?: Maybe<UpdateQuestionnaireFromNeo4JPayload>;
   getTransloaditToken?: Maybe<GetTransloaditTokenPayload>;
@@ -2295,6 +2323,12 @@ export type MutationCreateMatterDocumentFromUploadUrlArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationCreatePrimaryKeyIdIfNotExistsArgs = {
   input: CreatePrimaryKeyIdIfNotExistsInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateRelationshipArgs = {
+  input: CreateRelationshipInput;
 };
 
 

--- a/packages/server/migrations/committed/000087.sql
+++ b/packages/server/migrations/committed/000087.sql
@@ -1,0 +1,20 @@
+--! Previous: sha1:bc8dcdf1ff7879bc5825faac8c639a7df627a1ed
+--! Hash: sha1:bf1f38bd234d8294e7e74db54643bd609666912f
+
+-- Enter migration here
+
+DROP FUNCTION IF EXISTS create_relationship;
+CREATE OR REPLACE FUNCTION create_relationship(relationship TEXT, from_id UUID, from_type TEXT, to_id UUID, to_type TEXT) RETURNS TEXT AS $$
+BEGIN
+  PERFORM graphile_worker.add_job(
+    'createNeo4jRelationship',
+    json_build_object('relationship', $1, 'fromId', $2, 'fromType', $3, 'toId', $4, 'toType', $5)
+  );
+  RETURN format('Created relationship %s from %s with id %s to %s with id %s', relationship, from_type, from_id, to_type, to_id);
+END;
+$$ LANGUAGE plpgsql;
+
+GRANT ALL PRIVILEGES ON FUNCTION create_relationship TO admin;
+REVOKE ALL PRIVILEGES ON FUNCTION create_relationship FROM anonymous;
+REVOKE ALL PRIVILEGES ON FUNCTION create_relationship FROM portal;
+REVOKE ALL PRIVILEGES ON FUNCTION create_relationship FROM lawyer;

--- a/packages/server/src/tasks/createNeo4jRelationship.ts
+++ b/packages/server/src/tasks/createNeo4jRelationship.ts
@@ -1,0 +1,28 @@
+import { neo4jDriver } from '../utils/neo4jDriver';
+
+export const createNeo4jRelationship = async (
+  payload, { logger }
+): Promise<void> => {
+  const { fromId, fromType, toId, toType, relationship } = payload;
+  const capitalize = (string) => {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+  };
+
+  const session = neo4jDriver({ databaseName: 'questionnaires' }).session();
+
+  try {
+    const neo4jQuery = await session.run(
+      `MATCH (a:${capitalize(fromType)} {id: $fromId}),`+
+      `(b:${capitalize(toType)} {id: $toId}) `+
+      `CREATE (a)-[r:${relationship}]->(b) ` +
+      'RETURN a,r,b',
+      { fromId, toId }
+    );
+    logger.info(JSON.stringify(neo4jQuery));
+
+  } catch(error) {
+    throw new Error(error);
+  } finally {
+    await session.close();
+  }
+};

--- a/packages/server/src/tasks/index.ts
+++ b/packages/server/src/tasks/index.ts
@@ -1,0 +1,6 @@
+export { createNeo4jRelationship } from './createNeo4jRelationship';
+export { saveDocumentInLongTermStorage } from './saveDocumentInLongTermStorage';
+export { sendWelcomeEmail } from './sendWelcomeEmail';
+export { updateQuestionnaireFromNeo4j } from './updateQuestionnaireFromNeo4j';
+export { upsertQuestionToNeo4j } from './upsertQuestionToNeo4j';
+export { upsertQuestionnaireToNeo4j } from './upsertQuestionnaireToNeo4j';

--- a/packages/server/src/tasks/updateQuestionnaireFromNeo4j.ts
+++ b/packages/server/src/tasks/updateQuestionnaireFromNeo4j.ts
@@ -60,7 +60,7 @@ export const updateQuestionnaireFromNeo4j = async (
     );
   } catch(error) {
     throw new Error(error);
-  }finally {
+  } finally {
     await session.close();
   }
 };

--- a/packages/server/src/workers.ts
+++ b/packages/server/src/workers.ts
@@ -1,20 +1,19 @@
 import 'dotenv/config';
+import {
+  createNeo4jRelationship,
+  saveDocumentInLongTermStorage,
+  sendWelcomeEmail,
+  updateQuestionnaireFromNeo4j,
+  upsertQuestionToNeo4j,
+  upsertQuestionnaireToNeo4j,
+} from './tasks';
 import Redis from 'ioredis';
 import { getLeakyBucketRateLimiter } from 'graphile-worker-rate-limiter';
 import { default as neo4j } from 'neo4j-driver';
 import { postgresUrl } from './postgresUrl';
 import { redisUrl } from './redisUrl';
 import { run } from 'graphile-worker';
-import {
-  saveDocumentInLongTermStorage
-} from './tasks/saveDocumentInLongTermStorage';
-import { sendWelcomeEmail } from './tasks/sendWelcomeEmail';
 import { default as sgMail } from '@sendgrid/mail';
-import {
-  updateQuestionnaireFromNeo4j
-} from './tasks/updateQuestionnaireFromNeo4j';
-import { upsertQuestionToNeo4j } from './tasks/upsertQuestionToNeo4j';
-import { upsertQuestionnaireToNeo4j } from './tasks/upsertQuestionnaireToNeo4j';
 
 const redis = new Redis(redisUrl);
 const rateLimiter = getLeakyBucketRateLimiter({
@@ -54,6 +53,7 @@ async function workers() {
     noHandleSignals: false,
     pollInterval: 1000,
     taskList: {
+      createNeo4jRelationship,
       saveDocumentInLongTermStorage,
       sendWelcomeEmail: rateLimiter.wrapTask(sendWelcomeEmail),
       updateQuestionnaireFromNeo4j,


### PR DESCRIPTION
This commit adds a postgres function, `createRelationship`, which is
exposed to the web via Postgraphile. This function invokes the
`createNeo4jRelationship` `graphile-worker` task which creates the
passed in relationship between the passed in nodes.