### PR TITLE
re-allow the public folder in docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 .cache
 build
-public
 README.md
 neon_law.egg-info
 yarn-error.log
@@ -14,7 +13,6 @@ docker-compose.yml
 !docker/base.entrypoint.sh
 
 **/.cache
-**/public
 
 **/cypress
 **/cypress_cache


### PR DESCRIPTION
With gatsby, the build artifacts were added to the public folder, this
is not the case with Next.js as the build artifacts are included in
./public. This PR changes that so audio files can be uploaded to the
website.