### PR TITLE
add background logic for @auth0/next-js

### DIFF
--- a/infrastructure/kubernetes/main.tf
+++ b/infrastructure/kubernetes/main.tf
@@ -140,10 +140,11 @@ module "interface_deployment" {
 }
 
 module "law-job-resources_deployment" {
-  source      = "./modules/website_deployment"
-  app_name    = "law-job-resources"
-  environment = var.environment
-  image_url   = "${data.terraform_remote_state.gcp.outputs.container_registry}/law-job-resources:latest"
+  source               = "./modules/website_deployment"
+  app_name             = "law-job-resources"
+  environment          = var.environment
+  image_url            = "${data.terraform_remote_state.gcp.outputs.container_registry}/law-job-resources:latest"
+  next_js_auth0_secret = var.next_js_auth0_secret
 }
 
 module "ingress" {

--- a/infrastructure/kubernetes/main.tf
+++ b/infrastructure/kubernetes/main.tf
@@ -132,10 +132,11 @@ module "worker_deployment" {
 }
 
 module "interface_deployment" {
-  source      = "./modules/website_deployment"
-  app_name    = "interface"
-  environment = var.environment
-  image_url   = "${data.terraform_remote_state.gcp.outputs.container_registry}/interface:latest"
+  source               = "./modules/website_deployment"
+  app_name             = "interface"
+  environment          = var.environment
+  image_url            = "${data.terraform_remote_state.gcp.outputs.container_registry}/interface:latest"
+  next_js_auth0_secret = var.next_js_auth0_secret
 }
 
 module "law-job-resources_deployment" {

--- a/infrastructure/kubernetes/modules/website_deployment/main.tf
+++ b/infrastructure/kubernetes/modules/website_deployment/main.tf
@@ -26,6 +26,16 @@ resource "kubernetes_deployment" "interface" {
         container {
           image = var.image_url
           name  = var.app_name
+
+          env {
+            name  = "AUTH0_CLIENT_SECRET"
+            value = var.next_js_auth0_secret
+          }
+
+          env {
+            name  = "AUTH0_SECRET"
+            value = var.next_js_auth0_secret
+          }
         }
       }
     }

--- a/infrastructure/kubernetes/modules/website_deployment/variables.tf
+++ b/infrastructure/kubernetes/modules/website_deployment/variables.tf
@@ -1,8 +1,11 @@
-variable app_name {
+variable "app_name" {
 }
 
-variable image_url {
+variable "image_url" {
 }
 
-variable environment {
+variable "environment" {
+}
+
+variable "next_js_auth0_secret" {
 }

--- a/infrastructure/kubernetes/variables.tf
+++ b/infrastructure/kubernetes/variables.tf
@@ -42,3 +42,6 @@ variable "stripe_api_secret_key" {
 
 variable "environment" {
 }
+
+variable "next_js_auth0_secret" {
+}

--- a/web/.env.development
+++ b/web/.env.development
@@ -7,5 +7,5 @@ STRIPE_CLIENT_KEY=pk_test_JAfhStoX3mDLlUhj9LNmIFYq00vEQNAqI7
 
 AUTH0_SECRET='neon_law'
 AUTH0_BASE_URL="http://127.0.0.1:3000"
-AUTH0_ISSUER_BASE_URL="https://neon-law-testing.auth0.com.auth0.com"
-AUTH0_CLIENT_ID="dplmcTTWBbkd9j5jFd1LMr26c25Iugv7
+AUTH0_ISSUER_BASE_URL="https://neon-law-testing.auth0.com"
+AUTH0_CLIENT_ID="j8AVZJVtgj5BBPXnXcgNlF6zQGZaNzMa"

--- a/web/.env.production
+++ b/web/.env.production
@@ -5,3 +5,7 @@ NEXT_PUBLIC_SITE_URL=https://www.neonlaw.com
 TRANSLOADIT_ENDPOINT=https://transloadit.com/neon-law
 TRANSLOADIT_KEY=936fa2daa6ff40a1ba1105bbd072610b
 STRIPE_CLIENT_KEY=pk_live_LTR0BkpXLl0FfF01YBqDjR9Q00D7vvc8p2
+
+AUTH0_BASE_URL="https://www.neonlaw.com"
+AUTH0_ISSUER_BASE_URL="https://auth.neonlaw.com"
+AUTH0_CLIENT_ID="iaYjOkzzxmEVIez8z4DXqe7ZIieNYJ2S"

--- a/web/.env.staging
+++ b/web/.env.staging
@@ -6,3 +6,8 @@ TRANSLOADIT_ENDPOINT=https://transloadit.com/neon-law-staging
 TRANSLOADIT_KEY=79c310b348b04313ac9a819bd916fc83
 TRANSLOADIT_TEMPLATE_ID=34fbc891974142de84905eac7245b64a
 STRIPE_CLIENT_KEY=pk_test_JAfhStoX3mDLlUhj9LNmIFYq00vEQNAqI7
+
+AUTH0_SECRET='neon_law'
+AUTH0_BASE_URL="https://www.neonlaw.net"
+AUTH0_ISSUER_BASE_URL="https://neon-law-testing.auth0.com"
+AUTH0_CLIENT_ID="j8AVZJVtgj5BBPXnXcgNlF6zQGZaNzMa"

--- a/web/src/components/layouts/portalLayout.tsx
+++ b/web/src/components/layouts/portalLayout.tsx
@@ -13,11 +13,11 @@ import {
   PortalSideNavigation
 } from '../sideNavigation/portalSideNavigation';
 import React from 'react';
-// import { Redirect } from '@reach/router';
 import { getApolloClient } from '../../utils/getApolloClient';
 import { portalNavLinks } from '../navigationBars/portalNavLinks';
 import styled from '@emotion/styled';
 import { useColorMode } from '@chakra-ui/react';
+import { useRouter } from 'next/router';
 import { useUser } from '@auth0/nextjs-auth0';
 
 const StyledPortalLayout = styled.div`
@@ -102,48 +102,51 @@ export const PortalLayout = ({ children }) => {
     user,
   } = useUser();
   const apolloClient = getApolloClient();
+  const router = useRouter();
 
   if (isLoading) {
     return <LoadingPage />;
   }
 
-  // if (false) {
-  //   return <Redirect noThrow={true} to="/" />;
-  // }
-
   const links = portalNavLinks({ email: user.email });
 
-  return (
-    <ApolloProvider client={apolloClient}>
-      <StyledPortalLayout>
-        <div className="wrapper">
-          <Aside
-            style={{
-              background:
+  if (user) {
+    return (
+      <ApolloProvider client={apolloClient}>
+        <StyledPortalLayout>
+          <div className="wrapper">
+            <Aside
+              style={{
+                background:
                 colorMode === 'dark' ? '#000' : 'rgba(255, 255, 255, 0.8)',
-              color: colors.text[colorMode],
-              height: '100%',
-            }}
-          >
-            <PortalSideNavigation links={links} />
-          </Aside>
-          <PortalNavigationBar
-            isRenderedOnDashboard={true}
-            sideNavigationDrawer={<PortalSideNavContent links={links} />}
-          />
-          <Main
-            style={{
-              background: colorMode === 'dark' ? '#111' : theme.colors.white,
-              color: colors.text[colorMode],
-            }}
-          >
-            {children}
-          </Main>
-        </div>
-      </StyledPortalLayout>
-      <FooterWrapperMobile>
-        <BaseFooter hideTheSection={true} />
-      </FooterWrapperMobile>
-    </ApolloProvider>
-  );
+                color: colors.text[colorMode],
+                height: '100%',
+              }}
+            >
+              <PortalSideNavigation links={links} />
+            </Aside>
+            <PortalNavigationBar
+              isRenderedOnDashboard={true}
+              sideNavigationDrawer={<PortalSideNavContent links={links} />}
+            />
+            <Main
+              style={{
+                background: colorMode === 'dark' ? '#111' : theme.colors.white,
+                color: colors.text[colorMode],
+              }}
+            >
+              {children}
+            </Main>
+          </div>
+        </StyledPortalLayout>
+        <FooterWrapperMobile>
+          <BaseFooter hideTheSection={true} />
+        </FooterWrapperMobile>
+      </ApolloProvider>
+    );
+  }
+
+  router.push('/');
+
+  return <p>Redirecting</p>;
 };

--- a/web/src/components/navigationBars/authenticatedDropdown.tsx
+++ b/web/src/components/navigationBars/authenticatedDropdown.tsx
@@ -9,12 +9,16 @@ import {
 import { Link } from '../../components/link';
 import React from 'react';
 import { UserAvatar } from '../userAvatar';
+import { useIntl } from 'react-intl';
+import { useRouter } from 'next/router';
 
 export const AuthenticatedDropdown = () => {
   const { colorMode } = useColorMode();
   const lighterBg = { dark: 'gray.700', light: 'gray.200' };
   const evenLighterBg = { dark: 'gray.600', light: 'gray.100' };
   const color = { dark: 'white', light: 'black' };
+  const router = useRouter();
+  const intl = useIntl();
 
   return (
     <Box
@@ -30,22 +34,25 @@ export const AuthenticatedDropdown = () => {
           bg={lighterBg[colorMode]}>
           <MenuItem
             as={Link}
-            onClick={() => console.log('/portal')}
+            cursor="pointer"
+            onClick={() => router.push('/portal')}
             _hover={{ backgroundColor: evenLighterBg[colorMode] }}
           >
-            components_navbar.auth_portal
+            {intl.formatMessage({ id: 'components_navbar.auth_portal' })}
           </MenuItem>
           <MenuItem
             as={Link}
-            onClick={() => console.log('/portal/settings')}
+            cursor="pointer"
+            onClick={() => router.push('/portal/settings')}
             _hover={{ backgroundColor: evenLighterBg[colorMode] }}
           >
-            components_navbar.auth_settings
+            {intl.formatMessage({ id: 'components_navbar.auth_settings' })}
           </MenuItem>
           <MenuItem
+            cursor="pointer"
             _hover={{ backgroundColor: evenLighterBg[colorMode] }}
           >
-                components_navbar.auth_logout
+            {intl.formatMessage({ id: 'components_navbar.auth_logout' })}
           </MenuItem>
         </MenuList>
       </Menu>

--- a/web/src/components/navigationBars/baseNavigationBar.tsx
+++ b/web/src/components/navigationBars/baseNavigationBar.tsx
@@ -14,7 +14,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 import React, { useState } from 'react';
-
+import { AuthenticatedDropdown } from './authenticatedDropdown';
 import { BlackLivesMatter } from './blackLivesMatter';
 import { ChevronDownIcon } from '@chakra-ui/icons';
 import { Container } from '../container';
@@ -25,6 +25,8 @@ import { Search } from './search';
 import { colors } from '../../styles/neonLaw';
 import styled from '@emotion/styled';
 import { useIntl } from 'react-intl';
+import { useRouter } from 'next/router';
+import { useUser } from '@auth0/nextjs-auth0';
 
 interface BaseNavigationBarProps {
   isRenderedOnDashboard?: boolean;
@@ -46,6 +48,11 @@ export const BaseNavigationBar = ({
   const { isOpen, onToggle, onClose } = useDisclosure();
   const [loginButtonDisabled, disableLoginButton] = useState(false);
   const intl = useIntl();
+  const router = useRouter();
+  const {
+    isLoading,
+    user,
+  } = useUser();
 
   return (
     <>
@@ -136,20 +143,24 @@ export const BaseNavigationBar = ({
                 </Box>
               ))}
 
-              <Flex>
-                <Box width="6px" />
-                <Button
-                  bg="transparent"
-                  border="1px"
-                  className="nav-content-desktop"
-                  disabled={loginButtonDisabled}
-                  onClick={() => {
-                    disableLoginButton(true);
-                  }}
-                >
-                  {intl.formatMessage({ id: 'auth.login' })}
-                </Button>
-              </Flex>
+              { isLoading ? null :
+                user ? <AuthenticatedDropdown /> :
+                  <Flex>
+                    <Box width="6px" />
+                    <Button
+                      bg="transparent"
+                      border="1px"
+                      className="nav-content-desktop"
+                      disabled={loginButtonDisabled}
+                      onClick={() => {
+                        disableLoginButton(true);
+                        router.push('/api/auth/login');
+                      }}
+                    >
+                      {intl.formatMessage({ id: 'auth.login' })}
+                    </Button>
+                  </Flex>
+              }
               <IconButton
                 className="nav-content-mobile"
                 aria-label="Navigation Menu"

--- a/web/src/components/navigationBars/portalNavigationBar.tsx
+++ b/web/src/components/navigationBars/portalNavigationBar.tsx
@@ -16,7 +16,7 @@ import {
 } from '@chakra-ui/react';
 import React, { useState } from 'react';
 import { colors, gutters, theme } from '../../styles/neonLaw';
-// import { AuthenticatedDropdown } from './authenticatedDropdown';
+import { AuthenticatedDropdown } from './authenticatedDropdown';
 import { ChevronDownIcon } from '@chakra-ui/icons';
 import { Container } from '../container';
 import { Link } from '../link';
@@ -149,25 +149,7 @@ export const PortalNavigationBar = ({
                 </Box>
               ))}
 
-              {/* {isLoading ? null : false ? (
-                <AuthenticatedDropdown />
-              ) : ( */}
-              <Flex>
-                <Box width="6px" />
-                <Button
-                  bg="transparent"
-                  border="1px"
-                  className="nav-content-desktop"
-                  disabled={loginButtonDisabled}
-                  onClick={() => {
-                    disableLoginButton(true);
-                    console.log();
-                  }}
-                >
-                  {intl.formatMessage({ id: 'auth.login' })}
-                </Button>
-              </Flex>
-              {/* )} */}
+              <AuthenticatedDropdown />
 
               <IconButton
                 aria-label="Navigation Menu"

--- a/web/src/components/navigationBars/portalNavigationBar.tsx
+++ b/web/src/components/navigationBars/portalNavigationBar.tsx
@@ -14,17 +14,15 @@ import {
   useColorModeValue,
   useDisclosure,
 } from '@chakra-ui/react';
-import React, { useState } from 'react';
 import { colors, gutters, theme } from '../../styles/neonLaw';
 import { AuthenticatedDropdown } from './authenticatedDropdown';
 import { ChevronDownIcon } from '@chakra-ui/icons';
 import { Container } from '../container';
 import { Link } from '../link';
 import { MdDehaze } from 'react-icons/md';
+import React from 'react';
 import { Search } from './search';
 import styled from '@emotion/styled';
-import { useIntl } from 'react-intl';
-// import { useUser } from '@auth0/nextjs-auth0';
 
 interface BaseNavigationBarProps {
   isRenderedOnDashboard?: boolean;
@@ -51,10 +49,6 @@ export const PortalNavigationBar = ({
   sideNavigationDrawer,
 }: BaseNavigationBarProps) => {
   const { isOpen, onToggle, onClose } = useDisclosure();
-  const intl = useIntl();
-
-  const [loginButtonDisabled, disableLoginButton] = useState(false);
-  // const { isLoading } = useUser();
 
   return (
     <StyledHead>


### PR DESCRIPTION
Because Next.JS has a server, the auth0 library uses a regular
authentication flow instead of the Single-Page Application setting which
was previously used. This allows us to encrypt sessions and use a local
routing system to interface with Auth0. It's also nice that Next.JS is a
first-class citizen in the Auth0 ecosystem.