### PR TITLE
Relicense the code under the Neon License

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,115 +1,170 @@
-# PolyForm Noncommercial License 1.0.0
+# Neon License
 
-<https://polyformproject.org/licenses/noncommercial/1.0.0>
+## Overview
 
-## Acceptance
+This license is identical to the Apache License, Version 2.0 with one extra
+provision, Section 10 below. In short, as a law firm we must disclaim that if
+you use our software in one of your projects, you agree that we are **not**
+giving you legal advice.
 
-In order to get any license under these terms, you must agree to them as both
-strict obligations and conditions to all your licenses.
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-## Copyright License
+1. Definitions.
 
-The licensor grants you a copyright license for the software to do everything
-you might do with the software that would otherwise infringe the licensor's
-copyright in it for any permitted purpose. However, you may only distribute
-the software according to [Distribution License](#distribution-license) and
-make changes or new works based on the software according to [Changes and New
-Works License](#changes-and-new-works-license).
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 10 of this document.
 
-## Distribution License
+"Licensor" shall mean the copyright owner or entity authorized by the
+copyright owner that is granting the License.
 
-The licensor grants you an additional copyright license to distribute copies
-of the software. Your license to distribute covers distributing the software
-with changes and new works permitted by [Changes and New Works
-License](#changes-and-new-works-license).
+"Legal Entity" shall mean the union of the acting entity and all other
+entities that control, are controlled by, or are under common control with
+that entity. For the purposes of this definition, "control" means (i) the
+power, direct or indirect, to cause the direction or management of such
+entity, whether by contract or otherwise, or (ii) ownership of fifty percent
+(50%) or more of the outstanding shares, or (iii) beneficial ownership of
+such entity.
 
-## Notices
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
 
-You must ensure that anyone who gets a copy of any part of the software from
-you also gets a copy of these terms or the URL for them above, as well as
-copies of any plain-text lines beginning with `Required Notice:` that the
-licensor provided with the software. For example:
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation source, and
+configuration files.
 
-> Required Notice: Copyright Neon Law (https://www.neonlaw.com)
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object
+code, generated documentation, and conversions to other media types.
 
-## Changes and New Works License
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that is
+included in or attached to the work (an example is provided in the Appendix
+below).
 
-The licensor grants you an additional copyright license to make changes and
-new works based on the software for any permitted purpose.
+"Derivative Works" shall mean any work, whether in Source or Object form,
+that is based on (or derived from) the Work and for which the editorial
+revisions, annotations, elaborations, or other modifications represent, as a
+whole, an original work of authorship. For the purposes of this License,
+Derivative Works shall not include works that remain separable from, or
+merely link (or bind by name) to the interfaces of, the Work and Derivative
+Works thereof.
 
-## Patent License
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the
+purposes of this definition, "submitted" means any form of electronic,
+verbal, or written communication sent to the Licensor or its representatives,
+including but not limited to communication on electronic mailing lists,
+source code control systems, and issue tracking systems that are managed by,
+or on behalf of, the Licensor for the purpose of discussing and improving the
+Work, but excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
 
-The licensor grants you a patent license for the software that covers patent
-claims the licensor can license, or becomes able to license, that you would
-infringe by using the software.
+"Contributor" shall mean Licensor and any individual or Legal Entity on
+behalf of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
 
-## Noncommercial Purposes
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source or
+Object form.
 
-Any noncommercial purpose is a permitted purpose.
+3. Grant of Patent License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell, import,
+and otherwise transfer the Work, where such license applies only to those
+patent claims licensable by such Contributor that are necessarily infringed
+by their Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You institute
+patent litigation against any entity (including a cross-claim or counterclaim
+in a lawsuit) alleging that the Work or a Contribution incorporated within
+the Work constitutes direct or contributory patent infringement, then any
+patent licenses granted to You under this License for that Work shall
+terminate as of the date such litigation is filed.
 
-## Personal Uses
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
 
-Personal use for research, experiment, and testing for the benefit of public
-knowledge, personal study, private entertainment, hobby projects, amateur
-pursuits, or religious observance, without any anticipated commercial
-application, is use for a permitted purpose.
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from
+the Source form of the Work, excluding those notices that do not pertain to
+any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then
+any Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those
+notices that do not pertain to any part of the Derivative Works, in at least
+one of the following places: within a NOTICE text file distributed as part of
+the Derivative Works; within the Source form or documentation, if provided
+along with the Derivative Works; or, within a display generated by the
+Derivative Works, if and wherever such third-party notices normally appear.
+The contents of the NOTICE file are for informational purposes only and do
+not modify the License. You may add Your own attribution notices within
+Derivative Works that You distribute, alongside or as an addendum to the
+NOTICE text from the Work, provided that such additional attribution notices
+cannot be construed as modifying the License.
 
-## Noncommercial Organizations
+You may add Your own copyright statement to Your modifications and may
+provide additional or different license terms and conditions for use,
+reproduction, or distribution of Your modifications, or for any such
+Derivative Works as a whole, provided Your use, reproduction, and
+distribution of the Work otherwise complies with the conditions stated in
+this License.
 
-Use by any charitable organization, educational institution, public research
-organization, public safety or health organization, environmental protection
-organization, or government institution is use for a permitted purpose
-regardless of the source of funding or obligations resulting from the
-funding.
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without any
+additional terms or conditions. Notwithstanding the above, nothing herein
+shall supersede or modify the terms of any separate license agreement you may
+have executed with Licensor regarding such Contributions.
 
-## Fair Use
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as
+required for reasonable and customary use in describing the origin of the
+Work and reproducing the content of the NOTICE file.
 
-You may have "fair use" rights for the software under the law. These terms do
-not limit them.
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any
+warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or
+FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining
+the appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
 
-## No Other Rights
+8. Limitation of Liability. In no event and under no legal theory, whether in
+tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to
+in writing, shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability
+to use the Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all other
+commercial damages or losses), even if such Contributor has been advised of
+the possibility of such damages.
 
-These terms do not allow you to sublicense or transfer any of your licenses
-to anyone else, or prevent the licensor from granting licenses to anyone
-else. These terms do not imply any other licenses.
+9. Accepting Warranty or Additional Liability. While redistributing the Work
+or Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such
+obligations, You may act only on Your own behalf and on Your sole
+responsibility, not on behalf of any other Contributor, and only if You agree
+to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
 
-## Patent Defense
-
-If you make any written claim that the software infringes or contributes to
-infringement of any patent, your patent license for the software granted
-under these terms ends immediately. If your company makes such a claim, your
-patent license ends immediately for work on behalf of your company.
-
-## Violations
-
-The first time you are notified in writing that you have violated any of
-these terms, or done anything with the software not covered by your licenses,
-your licenses can nonetheless continue if you come into full compliance with
-these terms, and take practical steps to correct past violations, within 32
-days of receiving notice. Otherwise, all your licenses end immediately.
-
-## No Liability
-
-***As far as the law allows, the software comes as is, without any warranty or
-condition, and the licensor will not be liable to you for any damages arising
-out of these terms or the use or nature of the software, under any kind of
-legal claim.***
-
-## Definitions
-
-The **licensor** is the individual or entity offering these terms, and the
-**software** is the software the licensor makes available under these terms.
-
-**You** refers to the individual or entity agreeing to these terms.
-
-**Your company** is any legal entity, sole proprietorship, or other kind of
-organization that you work for, plus all organizations that have control
-over, are under the control of, or are under common control with that
-organization. **Control** means ownership of substantially all the assets of
-an entity, or the power to direct its management and policies by vote,
-contract, or otherwise. Control can be direct or indirect.
-
-**Your licenses** are all the licenses granted to you for the software under
-*these terms.
-
-**Use** means anything you do with the software requiring one of your licenses.
+10. No Legal Advice. Notwhithstanding any of the above provisions, You agree
+    that Your use of the Work or Derivative Works thereof does not establish an
+    attorney-client relationship with the Licensor, or any affiliate. You
+    also agree that nothing contained in the Work or Derivative Works is
+    legal advice and that no such relationship exists between You and the
+    Licensor unless there is an explicit written contract.

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ gcloud container clusters get-credentials neon-law-staging
 
 ## Legal
 
-Copyright 2020 Neon Law. Licensed under the [Polyform Noncommercial License
-1.0.0](LICENSE.md). Please contact us if you have any questions at
-support@neonlaw.com.
+Copyright 2020 Neon Law. Licensed under the [Neon License](LICENSE.md). The Neon
+License is the same as the Apache License Version 2 with the additional
+disclaimer that nothing provided herein is legal advice.
+
+Please contact us if you have any questions at support@neonlaw.com.

--- a/git_flow/Cargo.toml
+++ b/git_flow/Cargo.toml
@@ -3,7 +3,6 @@ name = "git_flow"
 version = "0.0.4"
 authors = ["support@neonlaw.com <support@neonlaw.com>"]
 edition = "2018"
-license = "Apache-2.0"
 repository = "https://github.com/neonlaw/codebase"
 documentation = "https://github.com/neonlaw/codebase/tree/development/git_flow/README.md"
 description = "A CLI for an opiniated git flow for monorepos on GitHub"

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@neonlaw/server",
   "version": "0.0.1",
-  "license": "PolyForm-Noncommercial-1.0.0",
+  "private": true,
   "author": "@neonlaw",
   "scripts": {
     "start": "ts-node --transpile-only src/server.ts",


### PR DESCRIPTION
While we are still awaiting approval from the OSI, we are re-licensing
this project under the Neon License for anyone who wishes to use the
codebase. You can use anything here with the same rights as the Apache
2 license so long as you agree that we are **not** providing you with
legal advice.