### PR TITLE
extract typsecript and markdown workflows

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -43,12 +43,6 @@ jobs:
           docker exec shell yarn install --frozen-lockfile --no-cache
           sudo chown -R $USER .
           yarn install --frozen-lockfile
-      - name: Lint Markdown files.
-        run: docker exec shell yarn markdown-lint
-      - name: Lint JavaScript files.
-        run: docker exec shell yarn lint
-      - name: Type-check TypeScript Files.
-        run: docker exec shell yarn check-types
       - name: Build Next.JS website
         run: docker exec shell yarn workspace @neonlaw/web build
       - name: Run Jest tests and publish coverage to Code Climate.

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -1,0 +1,26 @@
+---
+name: markdown
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**/*.md'
+      - '**/*.mdx'
+
+jobs:
+  test_suite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Lint Markdown files.
+        run: docker exec shell yarn markdown-lint

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -24,6 +24,12 @@ jobs:
         run: cd ./git_flow && cargo publish
         if: startsWith(github.ref, 'refs/tags/git_flow@')
 
+  update_i18n_package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
       - name: Publish @neonlaw/i18n
         run: cd ./i18n && npm publish --access public
         if: startsWith(github.ref, 'refs/tags/i18n@')

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -1,0 +1,28 @@
+---
+name: typescript
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**/*.ts'
+      - '**/*.tsx'
+
+jobs:
+  test_suite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Lint JavaScript files.
+        run: docker exec shell yarn lint
+      - name: Type-check TypeScript Files.
+        run: docker exec shell yarn check-types

--- a/.remarkignore
+++ b/.remarkignore
@@ -1,4 +1,4 @@
 node_modules/
 LICENSE.md
-packages/interface/src/content/index.mdx
-packages/interface/src/content/about-us.mdx
+packages/web/src/content/index.mdx
+packages/web/src/content/about-us.mdx


### PR DESCRIPTION
In an attempt to speed up CI/CD we should only run the necessary specs
when certain files change. This change moves typescript linting and
checking into its own workflow and extracts markdown linting and
checking into its own workflow. This should shorten CI/CD times spent
working on these specific workflows.