### PR TITLE
add test and code for a portal user to see their documents

### DIFF
--- a/server/migrations/committed/000106.sql
+++ b/server/migrations/committed/000106.sql
@@ -1,0 +1,22 @@
+--! Previous: sha1:c38e2dbc6a292782014315339114a21468c8cc95
+--! Hash: sha1:fbff9a20fd13470e02c85c1fb79fc5099a5c27b2
+
+-- Enter migration here
+
+CREATE INDEX IF NOT EXISTS letter_addressee_id ON letter (addressee_id);
+
+CREATE INDEX IF NOT EXISTS letter_addressor_id ON letter (addressor_id);
+
+CREATE INDEX IF NOT EXISTS response_person_id ON response (person_id);
+
+CREATE INDEX IF NOT EXISTS matter_contact_contact_id ON matter_contact (contact_id);
+
+CREATE INDEX IF NOT EXISTS matter_contact_matter_id ON matter_contact (matter_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS unique_contact_per_matter ON matter_contact (contact_id, matter_id);
+
+CREATE INDEX IF NOT EXISTS unprocessed_document_processed_document_id ON unprocessed_document (processed_document_id);
+
+CREATE INDEX IF NOT EXISTS unprocessed_document_document_template_id ON unprocessed_document (document_template_id);
+
+CREATE INDEX IF NOT EXISTS response_document_response_id ON response_document (response_id);

--- a/server/migrations/committed/000107.sql
+++ b/server/migrations/committed/000107.sql
@@ -1,0 +1,29 @@
+--! Previous: sha1:fbff9a20fd13470e02c85c1fb79fc5099a5c27b2
+--! Hash: sha1:c43d921c6dcb1a7a49288ecd4afb222f00fa9fb7
+
+-- Enter migration here
+
+CREATE OR REPLACE VIEW current_user_documents AS (
+  SELECT d.id as id FROM document d
+  INNER JOIN matter_document md ON (md.document_id = d.id)
+  INNER JOIN matter m ON (md.matter_id = m.id)
+  INNER JOIN person p ON (m.primary_contact_id = p.id)
+  WHERE p.id = (nullif(current_setting('person.id', true), '')::uuid)
+);
+
+GRANT SELECT ON current_user_documents TO portal;
+GRANT SELECT ON current_user_documents TO lawyer;
+GRANT SELECT ON current_user_documents TO admin;
+
+ALTER TABLE document ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS portal_select_document ON document;
+CREATE POLICY portal_select_document ON document FOR SELECT TO portal
+USING (id IN (SELECT * FROM current_user_documents));
+
+GRANT SELECT ON document TO portal;
+
+DROP POLICY IF EXISTS admin_select_document ON document;
+CREATE POLICY admin_select_document ON document FOR SELECT TO admin USING (true);
+
+GRANT ALL ON document TO admin;

--- a/server/tests/db/documents/selectDocuments.test.ts
+++ b/server/tests/db/documents/selectDocuments.test.ts
@@ -51,8 +51,7 @@ describe('SELECT * FROM document;', () => {
           matterTemplateId,
           primaryContactId
         });
-        console.log('rar');
-        const { id: ownMatterDocumentId } = await insertMatterDocumentFixture({
+        await insertMatterDocumentFixture({
           authorId: primaryContactId,
           client,
           documentId: ownDocumentId,
@@ -68,23 +67,20 @@ describe('SELECT * FROM document;', () => {
           client,
           primaryContactId: otherPersonId
         });
-        const {
-          id: otherMatterDocumentId
-        } = await insertMatterDocumentFixture({
-          authorId: primaryContactId,
+        await insertMatterDocumentFixture({
+          authorId: otherPersonId,
           client,
           documentId: otherDocumentId,
           matterId: otherMatterId,
         });
 
         await startPortalSession(client);
+
         const { rows } = await client.query('select * from document;');
 
-        console.log(rows);
-
         expect(rows).toHaveLength(1);
-        expect(rows[0]).toMatch(ownMatterDocumentId);
-        expect(rows[0]).not.toMatch(otherMatterDocumentId);
+        expect(rows[0].id).toEqual(ownDocumentId);
+        expect(JSON.stringify(rows[0])).not.toMatch(otherDocumentId);
       })
     );
   });

--- a/server/tests/db/documents/selectDocuments.test.ts
+++ b/server/tests/db/documents/selectDocuments.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it } from '@jest/globals';
 import {
-//   insertDocumentFixture,
-//   insertDocumentTemplateFixture,
-//   insertMatterDocumentFixture,
-//   insertMatterFixture,
-//   insertPersonFixture,
-//   startAdminSession,
+  insertDocumentFixture,
+  insertDocumentTemplateFixture,
+  insertMatterDocumentFixture,
+  insertMatterFixture,
+  insertMatterTemplateFixture,
+  insertPersonFixture,
+  selectPortalPerson,
   startAnonymousSession,
-  //   startLawyerSession,
-  //   startPortalSession,
+  startLawyerSession,
+  startPortalSession,
   withRootDb
 } from '../../utils/dbHelpers';
 
@@ -25,91 +26,107 @@ describe('SELECT * FROM document;', () => {
     );
   });
 
-  //   describe('a portal user', () => {
-  //     it('can only select documents from matters they belong to', () =>
-  //       withRootDb(async (pgClient: any) => {
-  //         const {
-  // id: currentPersonId  } = await startPortalSession(pgClient);
+  describe('a portal user', () => {
+    it('can only select documents from matters they belong to', () =>
+      withRootDb(async (client: any) => {
+        const { id: primaryContactId } = await selectPortalPerson({ client });
 
-  //         const {
-  //           id: documentTemplateId
-  //         } = await insertDocumentTemplateFixture();
+        const {
+          id: documentTemplateId
+        } = await insertDocumentTemplateFixture({ client });
 
-  //         const {
-  //           id: ownDocumentId
-  //         } = await insertDocumentTemplateFixture({ documentTemplateId });
-  //         const { id: ownMatterId } = await insertMatterFixture({
-  //           primaryContactId: currentPersonId
-  //         });
-  //         const {
-  // id: ownMatterDocumentId } = await insertMatterDocumentFixture({
-  //           documentId: ownDocumentId,
-  //           matterId: ownMatterId,
-  //         });
+        const {
+          id: matterTemplateId
+        } = await insertMatterTemplateFixture({ client });
 
-  //         const {
-  //           id: otherDocumentId
-  //         } = await insertDocumentTemplateFixture({ documentTemplateId });
-  //         const { id: otherMatterId } = await insertMatterFixture({
-  //           primaryContactId: currentPersonId
-  //         });
-  //         const {
-  //           id: otherMatterDocumentId
-  //         } = await insertMatterDocumentFixture({
-  //           documentId: otherDocumentId,
-  //           matterId: otherMatterId,
-  //         });
+        const {
+          id: ownDocumentTemplateId
+        } = await insertDocumentTemplateFixture({ client });
+        const { id: ownDocumentId } = await insertDocumentFixture({
+          client,
+          documentTemplateId: ownDocumentTemplateId
+        });
+        const { id: ownMatterId } = await insertMatterFixture({
+          client,
+          matterTemplateId,
+          primaryContactId
+        });
+        console.log('rar');
+        const { id: ownMatterDocumentId } = await insertMatterDocumentFixture({
+          authorId: primaryContactId,
+          client,
+          documentId: ownDocumentId,
+          matterId: ownMatterId,
+        });
 
-  //         const { rows } = await pgClient.query('select * from document;');
+        const { id: otherPersonId } = await insertPersonFixture({ client });
+        const { id: otherDocumentId } = await insertDocumentFixture({
+          client,
+          documentTemplateId
+        });
+        const { id: otherMatterId } = await insertMatterFixture({
+          client,
+          primaryContactId: otherPersonId
+        });
+        const {
+          id: otherMatterDocumentId
+        } = await insertMatterDocumentFixture({
+          authorId: primaryContactId,
+          client,
+          documentId: otherDocumentId,
+          matterId: otherMatterId,
+        });
 
-  //         console.log(rows);
+        await startPortalSession(client);
+        const { rows } = await client.query('select * from document;');
 
-  //         expect(rows).toHaveLength(1);
-  //         expect(rows[0]).toMatch(ownMatterDocumentId);
-  //         expect(rows[0]).not.toMatch(otherMatterDocumentId);
-  //       })
-  //     );
-  //   });
+        console.log(rows);
 
-  //   describe('a lawyer user', () => {
-  //     it('can only select documents from matters they belong to', () =>
-  //       withRootDb(async (pgClient: any) => {
-  //         await startLawyerSession(pgClient);
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatch(ownMatterDocumentId);
+        expect(rows[0]).not.toMatch(otherMatterDocumentId);
+      })
+    );
+  });
 
-  //         await
-  // expect(pgClient.query('select * from letter;')).rejects.toThrow(
-  //           /permission denied for table letter/
-  //         );
-  //       })
-  //     );
-  //   });
+  describe('a lawyer user', () => {
+    it('can only select documents from matters they belong to', () =>
+      withRootDb(async (pgClient: any) => {
+        await startLawyerSession(pgClient);
 
-  //   describe('a admin user', () => {
-  //     it('can select all documents', () =>
-  //       withRootDb(async (pgClient: any) => {
-  //         await pgClient.query('DELETE FROM letter;');
-  //         const { id: personId } = await insertPersonFixture(pgClient);
-  //         const { id: addresseeId } = await insertAddressFixture({
-  //           client: pgClient,
-  //           personId
-  //         });
-  //         const { id: addressorId } = await insertAddressFixture({
-  //           client: pgClient,
-  //           personId
-  //         });
+        expect(pgClient.query('select * from document;')).rejects.toThrow(
+          /permission denied for table document/
+        );
+      })
+    );
+  });
 
-  //         await insertLetterFixture({
-  //           addresseeId,
-  //           addressorId,
-  //           client: pgClient,
-  //         });
+  // describe('a admin user', () => {
+  //   it('can select all documents', () =>
+  //     withRootDb(async (pgClient: any) => {
+  //       await pgClient.query('DELETE FROM letter;');
+  //       const { id: personId } = await insertPersonFixture(pgClient);
+  //       const { id: addresseeId } = await insertAddressFixture({
+  //         client: pgClient,
+  //         personId
+  //       });
+  //       const { id: addressorId } = await insertAddressFixture({
+  //         client: pgClient,
+  //         personId
+  //       });
 
-  //         await startAdminSession(pgClient);
+  //       await insertLetterFixture({
+  //         addresseeId,
+  //         addressorId,
+  //         client: pgClient,
+  //       });
 
-  //         const { rows } = await pgClient.query('select * from letter;');
+  //       await startAdminSession(pgClient);
 
-//         expect(rows).toHaveLength(1);
-//       })
-//     );
-//   });
+  //       const { rows } = await pgClient.query('select * from letter;');
+
+  //       expect(rows).toHaveLength(1);
+  //     })
+  //   );
+  // });
 });

--- a/server/tests/db/letters/selectLetters.test.ts
+++ b/server/tests/db/letters/selectLetters.test.ts
@@ -49,27 +49,27 @@ describe('SELECT * FROM matter;', () => {
 
   describe('a admin user', () => {
     it('can select all letter', () =>
-      withRootDb(async (pgClient: any) => {
-        await pgClient.query('DELETE FROM letter;');
-        const { id: personId } = await insertPersonFixture(pgClient);
+      withRootDb(async (client: any) => {
+        await client.query('DELETE FROM letter;');
+        const { id: personId } = await insertPersonFixture({ client });
         const { id: addresseeId } = await insertAddressFixture({
-          client: pgClient,
+          client: client,
           personId
         });
         const { id: addressorId } = await insertAddressFixture({
-          client: pgClient,
+          client: client,
           personId
         });
 
         await insertLetterFixture({
           addresseeId,
           addressorId,
-          client: pgClient,
+          client: client,
         });
 
-        await startAdminSession(pgClient);
+        await startAdminSession(client);
 
-        const { rows } = await pgClient.query('select * from letter;');
+        const { rows } = await client.query('select * from letter;');
 
         expect(rows).toHaveLength(1);
       })

--- a/server/tests/db/people/selectPerson.test.ts
+++ b/server/tests/db/people/selectPerson.test.ts
@@ -12,10 +12,10 @@ import {
 describe('SELECT * FROM person;', () => {
   describe('an anonymous user', () => {
     it('cannot select users', () =>
-      withRootDb(async (pgClient: any) => {
-        await startAnonymousSession(pgClient);
+      withRootDb(async (client: any) => {
+        await startAnonymousSession(client);
 
-        await expect(pgClient.query('select * from person;')).rejects.toThrow(
+        await expect(client.query('select * from person;')).rejects.toThrow(
           /permission denied for table person/
         );
       })
@@ -24,11 +24,11 @@ describe('SELECT * FROM person;', () => {
 
   describe('a portal user', () => {
     it('only select users that are themself', () =>
-      withRootDb(async (pgClient: any) => {
-        await insertPersonFixture(pgClient);
+      withRootDb(async (client: any) => {
+        await insertPersonFixture({ client });
         const email = faker.internet.email();
-        await startPortalSession(pgClient, email);
-        const { rows } = await pgClient.query('select * from person;');
+        await startPortalSession(client, email);
+        const { rows } = await client.query('select * from person;');
 
         expect(rows).toHaveLength(1);
         expect(rows[0].email).toEqual(email);
@@ -38,12 +38,12 @@ describe('SELECT * FROM person;', () => {
 
   describe('a lawyer user', () => {
     it('only select users that are themself', () =>
-      withRootDb(async (pgClient: any) => {
-        await insertPersonFixture(pgClient);
+      withRootDb(async (client: any) => {
+        await insertPersonFixture({ client });
         const email = faker.internet.email();
-        await startLawyerSession(pgClient, email);
+        await startLawyerSession(client, email);
 
-        const { rows } = await pgClient.query('select * from person;');
+        const { rows } = await client.query('select * from person;');
 
         expect(rows).toHaveLength(1);
         expect(rows[0].email).toEqual(email);
@@ -53,12 +53,12 @@ describe('SELECT * FROM person;', () => {
 
   describe('a admin user', () => {
     it('selects all users', () =>
-      withRootDb(async (pgClient: any) => {
-        await insertPersonFixture(pgClient);
+      withRootDb(async (client: any) => {
+        await insertPersonFixture({ client });
         const email = faker.internet.email();
-        await startAdminSession(pgClient, email);
+        await startAdminSession(client, email);
 
-        const { rows } = await pgClient.query('select * from person;');
+        const { rows } = await client.query('select * from person;');
 
         expect(rows.length).toBeGreaterThanOrEqual(2);
       })

--- a/server/tests/utils/db/insertDocumentFixture.ts
+++ b/server/tests/utils/db/insertDocumentFixture.ts
@@ -1,0 +1,30 @@
+import * as faker from 'faker';
+
+interface InsertDocumentFixtureArgs {
+  client: any;
+  documentTemplateId: string;
+}
+
+export const insertDocumentFixture = async ({
+  client,
+  documentTemplateId
+}: InsertDocumentFixtureArgs) => {
+  const uuid = faker.datatype.uuid();
+  const gcpUrl =
+    'https://neon-law-staging-private-assets.storage.googleapis.com/'+
+    `matters/${uuid}/${uuid}.txt`;
+
+  const { rows } = await client.query(
+    'INSERT INTO document '+
+    '(filename, documentable_table_name, document_template_id, gcp_url) '+
+    'VALUES ($1, $2, $3, $4) RETURNING (id)',
+    [
+      `matters/${uuid}/${uuid}.txt`,
+      'matter_document',
+      documentTemplateId,
+      gcpUrl
+    ]
+  );
+
+  return rows[0];
+};

--- a/server/tests/utils/db/insertDocumentTemplateFixture.ts
+++ b/server/tests/utils/db/insertDocumentTemplateFixture.ts
@@ -1,0 +1,20 @@
+import * as faker from 'faker';
+
+interface InsertDocumentTemplateFixtureArgs {
+  client: any;
+}
+
+export const insertDocumentTemplateFixture = async ({
+  client
+}: InsertDocumentTemplateFixtureArgs) => {
+  const name = faker.lorem.slug();
+  const description = faker.lorem.paragraphs(2);
+
+  const { rows } = await client.query(
+    'INSERT INTO document_template (name, description) '+
+    'VALUES ($1, $2) RETURNING (id)',
+    [name, description]
+  );
+
+  return rows[0];
+};

--- a/server/tests/utils/db/insertMatterDocumentFixture.ts
+++ b/server/tests/utils/db/insertMatterDocumentFixture.ts
@@ -1,0 +1,21 @@
+interface  InsertMatterDocumentFixtureArgs {
+  client: any;
+  authorId: string;
+  documentId: string;
+  matterId: string;
+}
+
+export const insertMatterDocumentFixture = async ({
+  client,
+  documentId,
+  authorId,
+  matterId,
+}: InsertMatterDocumentFixtureArgs) => {
+  const { rows } = await client.query(
+    'INSERT INTO matter_document (document_id, author_id, matter_id) '+
+    'VALUES ($1, $2, $3) RETURNING (id)',
+    [documentId, authorId, matterId]
+  );
+
+  return rows[0];
+};

--- a/server/tests/utils/db/insertMatterFixture.ts
+++ b/server/tests/utils/db/insertMatterFixture.ts
@@ -51,5 +51,9 @@ export const insertMatterFixture = async ({
     ]
   );
 
-  return rows[0].row;
+  const { row } = rows[0];
+
+  const id = row.split(',')[0].replace(/\(/, '');
+
+  return { id };
 };

--- a/server/tests/utils/db/insertMatterTemplateFixture.ts
+++ b/server/tests/utils/db/insertMatterTemplateFixture.ts
@@ -1,8 +1,12 @@
 import * as faker from 'faker';
 
-export const insertMatterTemplateFixture = async (
-  client: any,
-) => {
+interface InsertMatterTemplateFixtureArgs {
+  client: any;
+}
+
+export const insertMatterTemplateFixture = async ({
+  client
+}: InsertMatterTemplateFixtureArgs) => {
   const uuid = faker.datatype.uuid();
 
   const { rows } = await client.query(

--- a/server/tests/utils/db/insertPersonFixture.ts
+++ b/server/tests/utils/db/insertPersonFixture.ts
@@ -1,6 +1,6 @@
 import * as faker from 'faker';
 
-export const insertPersonFixture = async (client: any) => {
+export const insertPersonFixture = async ({ client }) => {
   const email = faker.internet.email();
   const sub = faker.datatype.uuid();
 

--- a/server/tests/utils/db/selectPortalPerson.ts
+++ b/server/tests/utils/db/selectPortalPerson.ts
@@ -1,0 +1,17 @@
+interface SelectPortalPersonArgs {
+  client: any;
+}
+
+export const selectPortalPerson = async ({
+  client
+}: SelectPortalPersonArgs) => {
+  const email = 'portal@sink.sendgrid.com';
+  const { rows } = await client.query(
+    'INSERT INTO person (email, role, sub) ' +
+    'VALUES ($1, \'portal\', \'portal-sub\') '+
+    'ON CONFLICT("email") DO UPDATE SET email=EXCLUDED.email RETURNING id',
+    [email]
+  );
+  const { id } = rows[0];
+  return { email, id };
+};

--- a/server/tests/utils/dbHelpers.ts
+++ b/server/tests/utils/dbHelpers.ts
@@ -3,10 +3,16 @@ import { afterAll } from '@jest/globals';
 import { postgresUrl } from '../../src/postgresUrl';
 
 export { insertAddressFixture } from './db/insertAddressFixture';
+export { insertMatterDocumentFixture } from './db/insertMatterDocumentFixture';
+export {
+  insertDocumentTemplateFixture
+} from './db/insertDocumentTemplateFixture';
+export { insertDocumentFixture } from './db/insertDocumentFixture';
 export { insertMatterFixture } from './db/insertMatterFixture';
 export { insertMatterTemplateFixture } from './db/insertMatterTemplateFixture';
 export { insertPersonFixture } from './db/insertPersonFixture';
 export { insertLetterFixture } from './db/insertLetterFixture';
+export { selectPortalPerson } from './db/selectPortalPerson';
 
 const pools: any = {};
 

--- a/web/src/utils/api.tsx
+++ b/web/src/utils/api.tsx
@@ -150,6 +150,32 @@ export type Address = Node & {
   name?: Maybe<Scalars['String']>;
   /** Reads a single `Person` that is related to this `Address`. */
   person?: Maybe<Person>;
+  /** Reads and enables pagination through a set of `Letter`. */
+  lettersByAddresseeId: LettersConnection;
+  /** Reads and enables pagination through a set of `Letter`. */
+  lettersByAddressorId: LettersConnection;
+};
+
+
+export type AddressLettersByAddresseeIdArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<LettersOrderBy>>;
+  condition?: Maybe<LetterCondition>;
+};
+
+
+export type AddressLettersByAddressorIdArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<LettersOrderBy>>;
+  condition?: Maybe<LetterCondition>;
 };
 
 /** A condition to be used against `Address` object types. All fields are tested for equality and combined with a logical ‘and.’ */
@@ -349,6 +375,10 @@ export type CreateLetterPayload = {
   letter?: Maybe<Letter>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
+  /** Reads a single `Address` that is related to this `Letter`. */
+  addressee?: Maybe<Address>;
+  /** Reads a single `Address` that is related to this `Letter`. */
+  addressor?: Maybe<Address>;
   /** An edge for our `Letter`. May be used by Relay 1. */
   letterEdge?: Maybe<LettersEdge>;
 };
@@ -382,6 +412,10 @@ export type CreateMatterContactPayload = {
   matterContact?: Maybe<MatterContact>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
+  /** Reads a single `Person` that is related to this `MatterContact`. */
+  contact?: Maybe<Person>;
+  /** Reads a single `Matter` that is related to this `MatterContact`. */
+  matter?: Maybe<Matter>;
   /** An edge for our `MatterContact`. May be used by Relay 1. */
   matterContactEdge?: Maybe<MatterContactsEdge>;
 };
@@ -604,6 +638,8 @@ export type CreateResponsePayload = {
   query?: Maybe<Query>;
   /** Reads a single `Question` that is related to this `Response`. */
   question?: Maybe<Question>;
+  /** Reads a single `Person` that is related to this `Response`. */
+  person?: Maybe<Person>;
   /** An edge for our `Response`. May be used by Relay 1. */
   responseEdge?: Maybe<ResponsesEdge>;
 };
@@ -641,6 +677,38 @@ export type CreateTransloaditTokenPayload = {
   expires?: Maybe<Scalars['String']>;
   signature?: Maybe<Scalars['String']>;
 };
+
+export type CurrentUserDocument = {
+  __typename?: 'CurrentUserDocument';
+  id?: Maybe<Scalars['UUID']>;
+};
+
+/** A connection to a list of `CurrentUserDocument` values. */
+export type CurrentUserDocumentsConnection = {
+  __typename?: 'CurrentUserDocumentsConnection';
+  /** A list of `CurrentUserDocument` objects. */
+  nodes: Array<CurrentUserDocument>;
+  /** A list of edges which contains the `CurrentUserDocument` and cursor to aid in pagination. */
+  edges: Array<CurrentUserDocumentsEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `CurrentUserDocument` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `CurrentUserDocument` edge in the connection. */
+export type CurrentUserDocumentsEdge = {
+  __typename?: 'CurrentUserDocumentsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `CurrentUserDocument` at the end of the edge. */
+  node: CurrentUserDocument;
+};
+
+/** Methods to use when ordering `CurrentUserDocument`. */
+export enum CurrentUserDocumentsOrderBy {
+  Natural = 'NATURAL'
+}
 
 export type CurrentUserMatter = {
   __typename?: 'CurrentUserMatter';
@@ -897,6 +965,10 @@ export type DeleteLetterPayload = {
   deletedLetterNodeId?: Maybe<Scalars['ID']>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
+  /** Reads a single `Address` that is related to this `Letter`. */
+  addressee?: Maybe<Address>;
+  /** Reads a single `Address` that is related to this `Letter`. */
+  addressor?: Maybe<Address>;
   /** An edge for our `Letter`. May be used by Relay 1. */
   letterEdge?: Maybe<LettersEdge>;
 };
@@ -952,6 +1024,10 @@ export type DeleteMatterContactPayload = {
   deletedMatterContactNodeId?: Maybe<Scalars['ID']>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
+  /** Reads a single `Person` that is related to this `MatterContact`. */
+  contact?: Maybe<Person>;
+  /** Reads a single `Matter` that is related to this `MatterContact`. */
+  matter?: Maybe<Matter>;
   /** An edge for our `MatterContact`. May be used by Relay 1. */
   matterContactEdge?: Maybe<MatterContactsEdge>;
 };
@@ -1274,6 +1350,8 @@ export type DeleteResponseDocumentPayload = {
   query?: Maybe<Query>;
   /** Reads a single `Document` that is related to this `ResponseDocument`. */
   document?: Maybe<Document>;
+  /** Reads a single `Response` that is related to this `ResponseDocument`. */
+  response?: Maybe<Response>;
   /** An edge for our `ResponseDocument`. May be used by Relay 1. */
   responseDocumentEdge?: Maybe<ResponseDocumentsEdge>;
 };
@@ -1309,6 +1387,8 @@ export type DeleteResponsePayload = {
   query?: Maybe<Query>;
   /** Reads a single `Question` that is related to this `Response`. */
   question?: Maybe<Question>;
+  /** Reads a single `Person` that is related to this `Response`. */
+  person?: Maybe<Person>;
   /** An edge for our `Response`. May be used by Relay 1. */
   responseEdge?: Maybe<ResponsesEdge>;
 };
@@ -1353,6 +1433,10 @@ export type DeleteUnprocessedDocumentPayload = {
   deletedUnprocessedDocumentNodeId?: Maybe<Scalars['ID']>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
+  /** Reads a single `DocumentTemplate` that is related to this `UnprocessedDocument`. */
+  documentTemplate?: Maybe<DocumentTemplate>;
+  /** Reads a single `Document` that is related to this `UnprocessedDocument`. */
+  processedDocument?: Maybe<Document>;
   /** An edge for our `UnprocessedDocument`. May be used by Relay 1. */
   unprocessedDocumentEdge?: Maybe<UnprocessedDocumentsEdge>;
 };
@@ -1380,6 +1464,8 @@ export type Document = Node & {
   matterDocuments: MatterDocumentsConnection;
   /** Reads and enables pagination through a set of `ResponseDocument`. */
   responseDocuments: ResponseDocumentsConnection;
+  /** Reads and enables pagination through a set of `UnprocessedDocument`. */
+  unprocessedDocumentsByProcessedDocumentId: UnprocessedDocumentsConnection;
   downloadUrl?: Maybe<Scalars['String']>;
 };
 
@@ -1403,6 +1489,17 @@ export type DocumentResponseDocumentsArgs = {
   after?: Maybe<Scalars['Cursor']>;
   orderBy?: Maybe<Array<ResponseDocumentsOrderBy>>;
   condition?: Maybe<ResponseDocumentCondition>;
+};
+
+
+export type DocumentUnprocessedDocumentsByProcessedDocumentIdArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<UnprocessedDocumentsOrderBy>>;
+  condition?: Maybe<UnprocessedDocumentCondition>;
 };
 
 /**
@@ -1464,6 +1561,8 @@ export type DocumentTemplate = Node & {
   updatedAt: Scalars['Datetime'];
   /** Reads and enables pagination through a set of `Document`. */
   documents: DocumentsConnection;
+  /** Reads and enables pagination through a set of `UnprocessedDocument`. */
+  unprocessedDocuments: UnprocessedDocumentsConnection;
 };
 
 
@@ -1475,6 +1574,17 @@ export type DocumentTemplateDocumentsArgs = {
   after?: Maybe<Scalars['Cursor']>;
   orderBy?: Maybe<Array<DocumentsOrderBy>>;
   condition?: Maybe<DocumentCondition>;
+};
+
+
+export type DocumentTemplateUnprocessedDocumentsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<UnprocessedDocumentsOrderBy>>;
+  condition?: Maybe<UnprocessedDocumentCondition>;
 };
 
 /**
@@ -1547,6 +1657,10 @@ export type Letter = Node & {
   createdAt?: Maybe<Scalars['Datetime']>;
   addresseeId: Scalars['UUID'];
   addressorId: Scalars['UUID'];
+  /** Reads a single `Address` that is related to this `Letter`. */
+  addressee?: Maybe<Address>;
+  /** Reads a single `Address` that is related to this `Letter`. */
+  addressor?: Maybe<Address>;
 };
 
 /** A condition to be used against `Letter` object types. All fields are tested for equality and combined with a logical ‘and.’ */
@@ -1555,6 +1669,10 @@ export type LetterCondition = {
   id?: Maybe<Scalars['UUID']>;
   /** Checks for equality with the object’s `lobIdentifier` field. */
   lobIdentifier?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `addresseeId` field. */
+  addresseeId?: Maybe<Scalars['UUID']>;
+  /** Checks for equality with the object’s `addressorId` field. */
+  addressorId?: Maybe<Scalars['UUID']>;
 };
 
 /** An input for mutations affecting `Letter` */
@@ -1606,6 +1724,10 @@ export enum LettersOrderBy {
   IdDesc = 'ID_DESC',
   LobIdentifierAsc = 'LOB_IDENTIFIER_ASC',
   LobIdentifierDesc = 'LOB_IDENTIFIER_DESC',
+  AddresseeIdAsc = 'ADDRESSEE_ID_ASC',
+  AddresseeIdDesc = 'ADDRESSEE_ID_DESC',
+  AddressorIdAsc = 'ADDRESSOR_ID_ASC',
+  AddressorIdDesc = 'ADDRESSOR_ID_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -1629,6 +1751,8 @@ export type Matter = Node & {
   matterTemplate?: Maybe<MatterTemplate>;
   /** Reads and enables pagination through a set of `MatterDocument`. */
   matterDocuments: MatterDocumentsConnection;
+  /** Reads and enables pagination through a set of `MatterContact`. */
+  matterContacts: MatterContactsConnection;
 };
 
 
@@ -1641,6 +1765,18 @@ export type MatterMatterDocumentsArgs = {
   after?: Maybe<Scalars['Cursor']>;
   orderBy?: Maybe<Array<MatterDocumentsOrderBy>>;
   condition?: Maybe<MatterDocumentCondition>;
+};
+
+
+/** A legal matter, managed by Neon Law admin. */
+export type MatterMatterContactsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<MatterContactsOrderBy>>;
+  condition?: Maybe<MatterContactCondition>;
 };
 
 /** A condition to be used against `Matter` object types. All fields are tested for equality and combined with a logical ‘and.’ */
@@ -1669,6 +1805,10 @@ export type MatterContact = Node & {
   createdAt: Scalars['Datetime'];
   updatedAt: Scalars['Datetime'];
   role: Scalars['String'];
+  /** Reads a single `Person` that is related to this `MatterContact`. */
+  contact?: Maybe<Person>;
+  /** Reads a single `Matter` that is related to this `MatterContact`. */
+  matter?: Maybe<Matter>;
 };
 
 /**
@@ -1678,6 +1818,10 @@ export type MatterContact = Node & {
 export type MatterContactCondition = {
   /** Checks for equality with the object’s `id` field. */
   id?: Maybe<Scalars['UUID']>;
+  /** Checks for equality with the object’s `contactId` field. */
+  contactId?: Maybe<Scalars['UUID']>;
+  /** Checks for equality with the object’s `matterId` field. */
+  matterId?: Maybe<Scalars['UUID']>;
 };
 
 /** An input for mutations affecting `MatterContact` */
@@ -1727,6 +1871,10 @@ export enum MatterContactsOrderBy {
   Natural = 'NATURAL',
   IdAsc = 'ID_ASC',
   IdDesc = 'ID_DESC',
+  ContactIdAsc = 'CONTACT_ID_ASC',
+  ContactIdDesc = 'CONTACT_ID_DESC',
+  MatterIdAsc = 'MATTER_ID_ASC',
+  MatterIdDesc = 'MATTER_ID_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -2605,12 +2753,27 @@ export type Person = Node & {
   picture?: Maybe<Scalars['String']>;
   sub?: Maybe<Scalars['String']>;
   flags: Scalars['String'];
+  /** Reads and enables pagination through a set of `Response`. */
+  responses: ResponsesConnection;
   /** Reads and enables pagination through a set of `Matter`. */
   mattersByPrimaryContactId: MattersConnection;
   /** Reads and enables pagination through a set of `Address`. */
   addresses: AddressesConnection;
   /** Reads and enables pagination through a set of `MatterDocument`. */
   authoredMatterDocuments: MatterDocumentsConnection;
+  /** Reads and enables pagination through a set of `MatterContact`. */
+  matterContactsByContactId: MatterContactsConnection;
+};
+
+
+export type PersonResponsesArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<ResponsesOrderBy>>;
+  condition?: Maybe<ResponseCondition>;
 };
 
 
@@ -2644,6 +2807,17 @@ export type PersonAuthoredMatterDocumentsArgs = {
   after?: Maybe<Scalars['Cursor']>;
   orderBy?: Maybe<Array<MatterDocumentsOrderBy>>;
   condition?: Maybe<MatterDocumentCondition>;
+};
+
+
+export type PersonMatterContactsByContactIdArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<MatterContactsOrderBy>>;
+  condition?: Maybe<MatterContactCondition>;
 };
 
 /** A condition to be used against `Person` object types. All fields are tested for equality and combined with a logical ‘and.’ */
@@ -2684,6 +2858,8 @@ export type Query = Node & {
   node?: Maybe<Node>;
   /** Reads and enables pagination through a set of `Address`. */
   addresses?: Maybe<AddressesConnection>;
+  /** Reads and enables pagination through a set of `CurrentUserDocument`. */
+  currentUserDocuments?: Maybe<CurrentUserDocumentsConnection>;
   /** Reads and enables pagination through a set of `CurrentUserMatter`. */
   currentUserMatters?: Maybe<CurrentUserMattersConnection>;
   /** Reads and enables pagination through a set of `DocumentTemplate`. */
@@ -2772,6 +2948,17 @@ export type QueryAddressesArgs = {
   after?: Maybe<Scalars['Cursor']>;
   orderBy?: Maybe<Array<AddressesOrderBy>>;
   condition?: Maybe<AddressCondition>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryCurrentUserDocumentsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<CurrentUserDocumentsOrderBy>>;
 };
 
 
@@ -3298,6 +3485,21 @@ export type Response = Node & {
   personId: Scalars['UUID'];
   /** Reads a single `Question` that is related to this `Response`. */
   question?: Maybe<Question>;
+  /** Reads a single `Person` that is related to this `Response`. */
+  person?: Maybe<Person>;
+  /** Reads and enables pagination through a set of `ResponseDocument`. */
+  responseDocuments: ResponseDocumentsConnection;
+};
+
+
+export type ResponseResponseDocumentsArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<ResponseDocumentsOrderBy>>;
+  condition?: Maybe<ResponseDocumentCondition>;
 };
 
 /**
@@ -3309,6 +3511,8 @@ export type ResponseCondition = {
   id?: Maybe<Scalars['UUID']>;
   /** Checks for equality with the object’s `questionId` field. */
   questionId?: Maybe<Scalars['UUID']>;
+  /** Checks for equality with the object’s `personId` field. */
+  personId?: Maybe<Scalars['UUID']>;
 };
 
 export type ResponseDocument = Node & {
@@ -3320,6 +3524,8 @@ export type ResponseDocument = Node & {
   responseId: Scalars['UUID'];
   /** Reads a single `Document` that is related to this `ResponseDocument`. */
   document?: Maybe<Document>;
+  /** Reads a single `Response` that is related to this `ResponseDocument`. */
+  response?: Maybe<Response>;
 };
 
 /**
@@ -3331,6 +3537,8 @@ export type ResponseDocumentCondition = {
   id?: Maybe<Scalars['UUID']>;
   /** Checks for equality with the object’s `documentId` field. */
   documentId?: Maybe<Scalars['UUID']>;
+  /** Checks for equality with the object’s `responseId` field. */
+  responseId?: Maybe<Scalars['UUID']>;
 };
 
 /** A connection to a list of `ResponseDocument` values. */
@@ -3362,6 +3570,8 @@ export enum ResponseDocumentsOrderBy {
   IdDesc = 'ID_DESC',
   DocumentIdAsc = 'DOCUMENT_ID_ASC',
   DocumentIdDesc = 'DOCUMENT_ID_DESC',
+  ResponseIdAsc = 'RESPONSE_ID_ASC',
+  ResponseIdDesc = 'RESPONSE_ID_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -3414,6 +3624,8 @@ export enum ResponsesOrderBy {
   IdDesc = 'ID_DESC',
   QuestionIdAsc = 'QUESTION_ID_ASC',
   QuestionIdDesc = 'QUESTION_ID_DESC',
+  PersonIdAsc = 'PERSON_ID_ASC',
+  PersonIdDesc = 'PERSON_ID_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -3428,6 +3640,23 @@ export type UnprocessedDocument = Node & {
   documentableId: Scalars['UUID'];
   documentTemplateId: Scalars['UUID'];
   processedDocumentId?: Maybe<Scalars['UUID']>;
+  /** Reads a single `DocumentTemplate` that is related to this `UnprocessedDocument`. */
+  documentTemplate?: Maybe<DocumentTemplate>;
+  /** Reads a single `Document` that is related to this `UnprocessedDocument`. */
+  processedDocument?: Maybe<Document>;
+};
+
+/**
+ * A condition to be used against `UnprocessedDocument` object types. All fields
+ * are tested for equality and combined with a logical ‘and.’
+ */
+export type UnprocessedDocumentCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: Maybe<Scalars['UUID']>;
+  /** Checks for equality with the object’s `documentTemplateId` field. */
+  documentTemplateId?: Maybe<Scalars['UUID']>;
+  /** Checks for equality with the object’s `processedDocumentId` field. */
+  processedDocumentId?: Maybe<Scalars['UUID']>;
 };
 
 /** Represents an update to a `UnprocessedDocument`. Fields that are set will be updated. */
@@ -3438,6 +3667,19 @@ export type UnprocessedDocumentPatch = {
   documentableId?: Maybe<Scalars['UUID']>;
   documentTemplateId?: Maybe<Scalars['UUID']>;
   processedDocumentId?: Maybe<Scalars['UUID']>;
+};
+
+/** A connection to a list of `UnprocessedDocument` values. */
+export type UnprocessedDocumentsConnection = {
+  __typename?: 'UnprocessedDocumentsConnection';
+  /** A list of `UnprocessedDocument` objects. */
+  nodes: Array<UnprocessedDocument>;
+  /** A list of edges which contains the `UnprocessedDocument` and cursor to aid in pagination. */
+  edges: Array<UnprocessedDocumentsEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `UnprocessedDocument` you could get from the connection. */
+  totalCount: Scalars['Int'];
 };
 
 /** A `UnprocessedDocument` edge in the connection. */
@@ -3454,6 +3696,10 @@ export enum UnprocessedDocumentsOrderBy {
   Natural = 'NATURAL',
   IdAsc = 'ID_ASC',
   IdDesc = 'ID_DESC',
+  DocumentTemplateIdAsc = 'DOCUMENT_TEMPLATE_ID_ASC',
+  DocumentTemplateIdDesc = 'DOCUMENT_TEMPLATE_ID_DESC',
+  ProcessedDocumentIdAsc = 'PROCESSED_DOCUMENT_ID_ASC',
+  ProcessedDocumentIdDesc = 'PROCESSED_DOCUMENT_ID_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -3638,6 +3884,10 @@ export type UpdateLetterPayload = {
   letter?: Maybe<Letter>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
+  /** Reads a single `Address` that is related to this `Letter`. */
+  addressee?: Maybe<Address>;
+  /** Reads a single `Address` that is related to this `Letter`. */
+  addressor?: Maybe<Address>;
   /** An edge for our `Letter`. May be used by Relay 1. */
   letterEdge?: Maybe<LettersEdge>;
 };
@@ -3698,6 +3948,10 @@ export type UpdateMatterContactPayload = {
   matterContact?: Maybe<MatterContact>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
+  /** Reads a single `Person` that is related to this `MatterContact`. */
+  contact?: Maybe<Person>;
+  /** Reads a single `Matter` that is related to this `MatterContact`. */
+  matter?: Maybe<Matter>;
   /** An edge for our `MatterContact`. May be used by Relay 1. */
   matterContactEdge?: Maybe<MatterContactsEdge>;
 };
@@ -4008,6 +4262,8 @@ export type UpdateResponsePayload = {
   query?: Maybe<Query>;
   /** Reads a single `Question` that is related to this `Response`. */
   question?: Maybe<Question>;
+  /** Reads a single `Person` that is related to this `Response`. */
+  person?: Maybe<Person>;
   /** An edge for our `Response`. May be used by Relay 1. */
   responseEdge?: Maybe<ResponsesEdge>;
 };
@@ -4055,6 +4311,10 @@ export type UpdateUnprocessedDocumentPayload = {
   unprocessedDocument?: Maybe<UnprocessedDocument>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
+  /** Reads a single `DocumentTemplate` that is related to this `UnprocessedDocument`. */
+  documentTemplate?: Maybe<DocumentTemplate>;
+  /** Reads a single `Document` that is related to this `UnprocessedDocument`. */
+  processedDocument?: Maybe<Document>;
   /** An edge for our `UnprocessedDocument`. May be used by Relay 1. */
   unprocessedDocumentEdge?: Maybe<UnprocessedDocumentsEdge>;
 };


### PR DESCRIPTION
A portal user can SELECT rows in the document table if its associated to
a matter document where they are the primary contact of the matter.