### PR TITLE
remove primary-contact search for matter-by-id

### DIFF
--- a/web/src/graphql/MatterById.graphql
+++ b/web/src/graphql/MatterById.graphql
@@ -3,10 +3,6 @@ query MatterById($id: UUID!) {
     id
     name
     description
-    primaryContact {
-      id
-      name
-    }
     matterTemplate {
       id
       name

--- a/web/src/utils/api.tsx
+++ b/web/src/utils/api.tsx
@@ -4647,10 +4647,7 @@ export type MatterByIdQuery = (
   & { matter?: Maybe<(
     { __typename?: 'Matter' }
     & Pick<Matter, 'id' | 'name' | 'description'>
-    & { primaryContact?: Maybe<(
-      { __typename?: 'Person' }
-      & Pick<Person, 'id' | 'name'>
-    )>, matterTemplate?: Maybe<(
+    & { matterTemplate?: Maybe<(
       { __typename?: 'MatterTemplate' }
       & Pick<MatterTemplate, 'id' | 'name' | 'category'>
     )>, matterDocuments: (
@@ -5696,10 +5693,6 @@ export const MatterByIdDocument = gql`
     id
     name
     description
-    primaryContact {
-      id
-      name
-    }
     matterTemplate {
       id
       name


### PR DESCRIPTION
The person table is protected with row-level-security. By removing this
from the MatterById, other people who are matter contacts can read the
matter.