### PR TITLE
remove mandatory author from matter document list

### DIFF
--- a/web/src/components/lists/matterDocumentsList.tsx
+++ b/web/src/components/lists/matterDocumentsList.tsx
@@ -12,8 +12,7 @@ export const MatterDocumentsList = ({ matterDocuments }) => {
             target="_blank"
             rel="noreferrer">
             <ListItem>
-              {matterDocument.document.filename} by
-              {matterDocument.author.name} which is a
+              {matterDocument.document.filename} which is a
               {matterDocument.document.documentTemplate.name}.
             </ListItem>
           </Box>


### PR DESCRIPTION
Some users like portal users cannot read all the people stored in the
`person` table. Therefore we remove the author mention from people for
now.