### PR TITLE
escape more "." as determined by CodeQL

### DIFF
--- a/server/src/resolvers/documentPlugin.ts
+++ b/server/src/resolvers/documentPlugin.ts
@@ -22,10 +22,10 @@ export const documentPlugin = makeExtendSchemaPlugin(() => {
           };
 
           const bucketName = gcpUrl.match(
-            /^https:\/\/(.*)\.storage.googleapis.com/
+            /^https:\/\/(.*)\.storage\.googleapis\.com/
           )[1];
           const filename = gcpUrl.match(
-            /^https:\/\/.*\.storage.googleapis.com\/(.*)$/
+            /^https:\/\/.*\.storage\.googleapis\.com\/(.*)$/
           )[1];
 
           const [url] = await storage


### PR DESCRIPTION
<img width="685" alt="Screen Shot 2021-04-10 at 10 47 00 PM" src="https://user-images.githubusercontent.com/889427/114293866-aa497700-9a4e-11eb-9b0e-c9f43f030e3d.png">
