### PR TITLE
[dyd]: correct the alignment of the FAQs title.

### DIFF
--- a/web/src/components/section.tsx
+++ b/web/src/components/section.tsx
@@ -49,7 +49,7 @@ export const Section = ({
             title ? <h2
               style={{
                 ...titleStyles,
-                // textAlign: isTitleCentered ? 'center' : 'left',
+                textAlign: isTitleCentered ? 'center' : 'left',
               }}
               className={`${
                 isTitleNotUnderlined


### PR DESCRIPTION
This Pr fixes the alignment of the FAQ section on the DYD page:

![image](https://user-images.githubusercontent.com/46004116/116795937-f50c5b00-aaf1-11eb-9a04-826a8d201dd1.png)
