### PR TITLE
revert to use jost as the font family for headings.

### DIFF
--- a/web/src/styles/baseStyles.tsx
+++ b/web/src/styles/baseStyles.tsx
@@ -67,7 +67,7 @@ export const BaseStyles = ({ dir }: BaseStylesProps): JSX.Element => {
         h2,
         h3,
         h4 {
-          font-family: ${dir === 'rtl' ? 'Noto Naskh Arabic' : 'HK Grotesk'},
+          font-family: ${dir === 'rtl' ? 'Noto Naskh Arabic' : 'Jost'},
             sans-serif ${dir.length && '!important'};
           font-weight: 400;
           line-height: 1.35 !important;


### PR DESCRIPTION
Addresses https://github.com/NeonLaw/codebase/pull/2290#issuecomment-831667091