### PR TITLE
add public pages for document templates and questions. 

### DIFF
--- a/web/src/components/tables/documentTemplateTable.tsx
+++ b/web/src/components/tables/documentTemplateTable.tsx
@@ -1,21 +1,27 @@
 import React from 'react';
 import { Table } from './base';
-import { useAllDocumentTemplatesQuery } from '../../utils/api';
 
 interface DocumentTemplateTableProps {
   onRowClick(row: any): void;
+  loading: boolean;
+  data: any;
+  error: any;
 }
 
 export const DocumentTemplateTable = (
-  props: DocumentTemplateTableProps
+  {
+    data,
+    error,
+    loading,
+    onRowClick,
+  }: DocumentTemplateTableProps
 ) => {
-  const { loading, data, error } = useAllDocumentTemplatesQuery();
 
   if (loading) {
-    return (<h1>Loading</h1>);
+    return (<p>Loading</p>);
   }
   if (error) {
-    return (<h1>{error}</h1>);
+    return (<p>{error}</p>);
   }
 
   const columns = [
@@ -35,7 +41,7 @@ export const DocumentTemplateTable = (
       columns={columns}
       data={nodes}
       testId="admin-document-template-table"
-      onRowClick={props.onRowClick}
+      onRowClick={onRowClick}
     />
   );
 };

--- a/web/src/components/tables/questionTable.tsx
+++ b/web/src/components/tables/questionTable.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
 import { Table } from './base';
-import { useAllQuestionsQuery } from '../../utils/api';
 
 interface QuestionTableProps {
   onRowClick(row: any): void;
+  loading: boolean;
+  data: any;
+  error: any;
 }
 
-export const QuestionTable = (props: QuestionTableProps) => {
-  const { loading, data, error } = useAllQuestionsQuery();
-
+export const QuestionTable = ({
+  data,
+  error,
+  loading,
+  onRowClick,
+}: QuestionTableProps) => {
   if (loading) {
-    return (<h1>Loading</h1>);
+    return <h1>Loading</h1>;
   }
   if (error) {
-    return (<h1>{error}</h1>);
+    return <h1>{error}</h1>;
   }
 
   const columns = [
@@ -37,7 +42,7 @@ export const QuestionTable = (props: QuestionTableProps) => {
       columns={columns}
       data={nodes}
       testId="admin-questions-table"
-      onRowClick={props.onRowClick}
+      onRowClick={onRowClick}
       defaultPageSize={50}
     />
   );

--- a/web/src/components/tables/questionTable.tsx
+++ b/web/src/components/tables/questionTable.tsx
@@ -15,10 +15,10 @@ export const QuestionTable = ({
   onRowClick,
 }: QuestionTableProps) => {
   if (loading) {
-    return <h1>Loading</h1>;
+    return <p>Loading...</p>;
   }
   if (error) {
-    return <h1>{error}</h1>;
+    return <p>{error}</p>;
   }
 
   const columns = [

--- a/web/src/pages/document-templates.tsx
+++ b/web/src/pages/document-templates.tsx
@@ -1,14 +1,16 @@
 import { Box } from '@chakra-ui/layout';
 import { Container } from '../components/container';
+import {
+  DocumentTemplateTable
+} from '../components/tables/documentTemplateTable';
 import { PublicLayout } from '../components/layouts/publicLayout';
-import { QuestionTable } from '../components/tables/questionTable';
 import React from 'react';
 import { gutters } from '../styles/neonLaw';
 import styled from '@emotion/styled';
-import { useAllQuestionsQuery } from '../utils/api';
+import { useAllDocumentTemplatesQuery } from '../utils/api';
 import { useDisclosure } from '@chakra-ui/hooks';
 
-const StyledQuestionsPage = styled.div`
+const StyledDocumentTemplatesPage = styled.div`
   h1 {
     margin-bottom: ${gutters.small};
   }
@@ -18,18 +20,18 @@ const StyledQuestionsPage = styled.div`
   }
 `;
 
-const QuestionsPage = () => {
+const DocumentTemplatesPage = () => {
   const { onOpen } = useDisclosure();
-  const { loading, data, error } = useAllQuestionsQuery();
+  const { loading, data, error } = useAllDocumentTemplatesQuery();
 
   return (
-    <StyledQuestionsPage>
+    <StyledDocumentTemplatesPage>
       <PublicLayout>
         <Container>
           <Box padding="9rem 0 4rem">
-            <h1>Questions</h1>
+            <h1>Document Templates</h1>
             <div className="questions-container">
-              <QuestionTable
+              <DocumentTemplateTable
                 loading={loading}
                 data={data}
                 error={error}
@@ -41,9 +43,9 @@ const QuestionsPage = () => {
           </Box>
         </Container>
       </PublicLayout>
-    </StyledQuestionsPage>
+    </StyledDocumentTemplatesPage>
   );
 };
 
 /* eslint-disable-next-line import/no-default-export */
-export default QuestionsPage;
+export default DocumentTemplatesPage;

--- a/web/src/pages/portal/admin/document-templates.tsx
+++ b/web/src/pages/portal/admin/document-templates.tsx
@@ -1,4 +1,5 @@
 import { Box, Kbd, useDisclosure } from '@chakra-ui/react';
+
 import { Button } from '../../../components/button';
 import {
   CreateDocumentTemplateModal
@@ -11,11 +12,13 @@ import {
   UpdateDocumentTemplateModal
 } from '../../../components/modals/updateDocumentTemplateModal';
 import { gutters } from '../../../styles/neonLaw';
+import { useAllDocumentTemplatesQuery } from '../../../utils/api';
 import { useState } from 'react';
 
 const AdminMatterDocumentTemplates = () => {
+  const { loading, data, error } = useAllDocumentTemplatesQuery();
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [showCreateModal, changeShowCreateModal ] = useState(true);
+  const [showCreateModal, changeShowCreateModal] = useState(true);
   const [currentRow, setCurrentRow] = useState(undefined);
 
   return (
@@ -60,6 +63,9 @@ const AdminMatterDocumentTemplates = () => {
             setCurrentRow(row);
             onOpen();
           }}
+          loading={loading}
+          data={data}
+          error={error}
         />
       </Box>
     </PortalLayout>

--- a/web/src/pages/portal/admin/questions.tsx
+++ b/web/src/pages/portal/admin/questions.tsx
@@ -1,4 +1,5 @@
 import { Box, Kbd, useDisclosure } from '@chakra-ui/react';
+
 import { Button } from '../../../components/button';
 import {
   CreateQuestionModal
@@ -11,12 +12,14 @@ import {
   UpdateQuestionModal
 } from '../../../components/modals/updateQuestionModal';
 import { gutters } from '../../../styles/neonLaw';
+import { useAllQuestionsQuery } from '../../../utils/api';
 import { useState } from 'react';
 
 const AdminQuestions = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [showCreateModal, changeShowCreateModal] = useState(true);
   const [currentRow, setCurrentRow] = useState(undefined);
+  const { loading, data, error } = useAllQuestionsQuery();
 
   return (
     <PortalLayout>
@@ -54,6 +57,9 @@ const AdminQuestions = () => {
         />
 
         <QuestionTable
+          loading={loading}
+          data={data}
+          error={error}
           onRowClick={(row) => {
             changeShowCreateModal(false);
             setCurrentRow(row);

--- a/web/src/pages/questions.tsx
+++ b/web/src/pages/questions.tsx
@@ -1,0 +1,45 @@
+import { gql, useQuery } from '@apollo/client';
+
+import { Box } from '@chakra-ui/layout';
+import { Container } from '../components/container';
+import { PublicLayout } from '../components/layouts/publicLayout';
+import { QuestionTable } from '../components/tables/questionTable';
+import React from 'react';
+import { useDisclosure } from '@chakra-ui/hooks';
+
+const QUERY = gql`
+  query Questions {
+    questions {
+      nodes {
+        id
+        prompt
+      }
+    }
+  }
+`;
+
+const QuestionsPage = () => {
+  const { onOpen } = useDisclosure();
+  const { loading, data, error } = useQuery(QUERY);
+
+  return (
+    <PublicLayout>
+      <Container>
+        <Box padding="9rem 0 4rem">
+          <h1>Questions</h1>
+          <QuestionTable
+            loading={loading}
+            data={data}
+            error={error}
+            onRowClick={() => {
+              onOpen();
+            }}
+          />
+        </Box>
+      </Container>
+    </PublicLayout>
+  );
+};
+
+/* eslint-disable-next-line import/no-default-export */
+export default QuestionsPage;

--- a/web/src/utils/getApolloClient.ts
+++ b/web/src/utils/getApolloClient.ts
@@ -1,4 +1,5 @@
 import { ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client';
+
 import fetch from 'isomorphic-fetch';
 import { setContext } from '@apollo/client/link/context';
 


### PR DESCRIPTION
Fixes #2275 

This is how the pages look: 

http://localhost:3000/questions

![image](https://user-images.githubusercontent.com/46004116/118376726-3a955180-b5e3-11eb-96b7-3b29c631c425.png)

http://localhost:3000/document-templates

![image](https://user-images.githubusercontent.com/46004116/118376757-58fb4d00-b5e3-11eb-9142-ea86d519ceab.png)

