### PR TITLE
add slugs to questions and matters

### DIFF
--- a/postgres/lib/neon_postgres/sequel_models.rb
+++ b/postgres/lib/neon_postgres/sequel_models.rb
@@ -32,5 +32,8 @@ module NeonPostgres
       many_to_one :matter
       many_to_one :author, class: :person, key: :author_id
     end
+
+    class Question < Sequel::Model
+    end
   end
 end

--- a/postgres/spec/queries/questions/create_questions_spec.rb
+++ b/postgres/spec/queries/questions/create_questions_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "insert into questions;" do
   let(:insert_question) {
     NeonPostgres::Models::Question.insert(
       prompt: prompt,
-      question_type: 'single-choice'
+      question_type: "single-choice"
     )
   }
 
@@ -43,12 +43,12 @@ RSpec.describe "insert into questions;" do
   context "as an admin user", :admin do
     let(:admin_user) { load(:person__admin_user) }
 
-    context 'with a correct slug' do
+    context "with a correct slug" do
       ["oeuoau-aoeu", "OEU-aoeuA"].each do |slug|
         it "creates a question with the slug #{slug}" do
           NeonPostgres::Models::Question.insert(
             prompt: prompt,
-            question_type: 'single-choice',
+            question_type: "single-choice",
             slug: slug
           )
           expect(NeonPostgres::Models::Question.count).to eq 1
@@ -57,13 +57,13 @@ RSpec.describe "insert into questions;" do
       end
     end
 
-    context 'with an incorrect slug' do
+    context "with an incorrect slug" do
       ["-oeuoau-aoeu", "O2U-aoeuA"].each do |slug|
         it "cannot create a question with the slug #{slug}" do
           expect do
             NeonPostgres::Models::Question.insert(
               prompt: prompt,
-              question_type: 'single-choice',
+              question_type: "single-choice",
               slug: slug
             )
           end.to raise_error(

--- a/postgres/spec/queries/questions/create_questions_spec.rb
+++ b/postgres/spec/queries/questions/create_questions_spec.rb
@@ -1,0 +1,77 @@
+RSpec.describe "insert into questions;" do
+  let(:connection) { NeonPostgres::Database.connection }
+  let(:seed_data) { nil }
+  let(:prompt) { "How are you?" }
+  let(:insert_question) {
+    NeonPostgres::Models::Question.insert(
+      prompt: prompt,
+      question_type: 'single-choice'
+    )
+  }
+
+  context "as an anonymous user", :anonymous do
+    it "denies access to the questions table" do
+      expect { insert_question }.to raise_error(
+        Sequel::DatabaseError,
+        /(PG::InsufficientPrivilege).*(permission denied for table questions)/
+      )
+    end
+  end
+
+  context "as a portal user", :portal do
+    let(:portal_user) { load(:person__portal_user) }
+
+    it "denies access to the questions table" do
+      expect { insert_question }.to raise_error(
+        Sequel::DatabaseError,
+        /(PG::InsufficientPrivilege).*(permission denied for table questions)/
+      )
+    end
+  end
+
+  context "as a lawyer user", :lawyer do
+    let(:lawyer_user) { load(:person__lawyer_user) }
+
+    it "denies access to the questions table" do
+      expect { insert_question }.to raise_error(
+        Sequel::DatabaseError,
+        /(PG::InsufficientPrivilege).*(permission denied for table questions)/
+      )
+    end
+  end
+
+  context "as an admin user", :admin do
+    let(:admin_user) { load(:person__admin_user) }
+
+    context 'with a correct slug' do
+      ["oeuoau-aoeu", "OEU-aoeuA"].each do |slug|
+        it "creates a question with the slug #{slug}" do
+          NeonPostgres::Models::Question.insert(
+            prompt: prompt,
+            question_type: 'single-choice',
+            slug: slug
+          )
+          expect(NeonPostgres::Models::Question.count).to eq 1
+          expect(NeonPostgres::Models::Question.all.first[:prompt]).to eq prompt
+        end
+      end
+    end
+
+    context 'with an incorrect slug' do
+      ["-oeuoau-aoeu", "O2U-aoeuA"].each do |slug|
+        it "cannot create a question with the slug #{slug}" do
+          expect do
+            NeonPostgres::Models::Question.insert(
+              prompt: prompt,
+              question_type: 'single-choice',
+              slug: slug
+            )
+          end.to raise_error(
+            Sequel::DatabaseError,
+            /(PG::CheckViolation).*(value for domain slug violates)/
+          )
+        end
+      end
+    end
+  end
+end

--- a/server/migrations/committed/000140.sql
+++ b/server/migrations/committed/000140.sql
@@ -1,0 +1,15 @@
+--! Previous: sha1:949cf8168d23a02420a0a4daf6411631eba41a1e
+--! Hash: sha1:4f7e0984f12408f072d5eb767b2e3cc5c4f99c47
+
+-- Enter migration here
+
+ALTER TABLE matters DROP COLUMN IF EXISTS slug;
+ALTER TABLE questions DROP COLUMN IF EXISTS slug;
+
+DROP DOMAIN IF EXISTS slug;
+CREATE DOMAIN slug AS text
+
+CHECK (VALUE ~ '^[a-zA-Z]+[a-zA-Z\-]*[a-zA-Z]$');
+
+ALTER TABLE matters ADD COLUMN IF NOT EXISTS slug slug;
+ALTER TABLE questions ADD COLUMN IF NOT EXISTS slug slug;

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -101,6 +101,14 @@ CREATE DOMAIN public.gcp_url AS text
 COMMENT ON DOMAIN public.gcp_url IS 'the GCP Storage URL of the private file.';
 
 
+--
+-- Name: slug; Type: DOMAIN; Schema: public; Owner: -
+--
+
+CREATE DOMAIN public.slug AS text
+	CONSTRAINT slug_check CHECK ((VALUE ~ '^[a-zA-Z]+[a-zA-Z\-]*[a-zA-Z]$'::text));
+
+
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
@@ -162,6 +170,7 @@ CREATE TABLE public.questions (
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     help_text json,
+    slug public.slug,
     CONSTRAINT question_question_type_check CHECK (((question_type)::text = ANY ((ARRAY['single-choice'::character varying, 'single-date'::character varying, 'single-file-upload'::character varying, 'single-line-text'::character varying, 'text'::character varying, 'date-range'::character varying, 'number'::character varying, 'multiple-file-upload'::character varying])::text[])))
 );
 
@@ -677,7 +686,8 @@ CREATE TABLE public.matters (
     primary_contact_id uuid,
     matter_template_id uuid NOT NULL,
     description json DEFAULT '{}'::json NOT NULL,
-    active boolean DEFAULT true NOT NULL
+    active boolean DEFAULT true NOT NULL,
+    slug public.slug
 );
 
 

--- a/web/src/utils/api.tsx
+++ b/web/src/utils/api.tsx
@@ -23,6 +23,7 @@ export type Scalars = {
   Datetime: string;
   /** The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
   JSON: { [key: string]: any };
+  Slug: any;
   /** the GCP Storage URL of the private file. */
   GcpUrl: any;
 };
@@ -1894,6 +1895,7 @@ export type Matter = Node & {
   matterTemplateId: Scalars['UUID'];
   description: Scalars['JSON'];
   active: Scalars['Boolean'];
+  slug?: Maybe<Scalars['Slug']>;
   /** Reads a single `Person` that is related to this `Matter`. */
   primaryContact?: Maybe<Person>;
   /** Reads a single `MatterTemplate` that is related to this `Matter`. */
@@ -2106,6 +2108,7 @@ export type MatterInput = {
   matterTemplateId: Scalars['UUID'];
   description?: Maybe<Scalars['JSON']>;
   active?: Maybe<Scalars['Boolean']>;
+  slug?: Maybe<Scalars['Slug']>;
 };
 
 /** Represents an update to a `Matter`. Fields that are set will be updated. */
@@ -2118,6 +2121,7 @@ export type MatterPatch = {
   matterTemplateId?: Maybe<Scalars['UUID']>;
   description?: Maybe<Scalars['JSON']>;
   active?: Maybe<Scalars['Boolean']>;
+  slug?: Maybe<Scalars['Slug']>;
 };
 
 /** A connection to a list of `Matter` values. */
@@ -3560,6 +3564,7 @@ export type Question = Node & {
   createdAt: Scalars['Datetime'];
   updatedAt: Scalars['Datetime'];
   helpText?: Maybe<Scalars['JSON']>;
+  slug?: Maybe<Scalars['Slug']>;
   /** Reads and enables pagination through a set of `Response`. */
   responses: ResponsesConnection;
   isLinkedToQuestionnaire?: Maybe<Scalars['Boolean']>;
@@ -3599,6 +3604,7 @@ export type QuestionInput = {
   createdAt?: Maybe<Scalars['Datetime']>;
   updatedAt?: Maybe<Scalars['Datetime']>;
   helpText?: Maybe<Scalars['JSON']>;
+  slug?: Maybe<Scalars['Slug']>;
 };
 
 export type Questionnaire = Node & {
@@ -3705,6 +3711,7 @@ export type QuestionPatch = {
   createdAt?: Maybe<Scalars['Datetime']>;
   updatedAt?: Maybe<Scalars['Datetime']>;
   helpText?: Maybe<Scalars['JSON']>;
+  slug?: Maybe<Scalars['Slug']>;
 };
 
 /** A connection to a list of `Question` values. */
@@ -3896,6 +3903,7 @@ export enum ResponsesOrderBy {
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
+
 
 export type Task = Node & {
   __typename?: 'Task';


### PR DESCRIPTION
part of #2350

We will need a second PR to apply a not-nullable after we add slugs to
all staging and production question/matters records