### PR TITLE
add more iam roles to the application-user

### DIFF
--- a/infrastructure/gcp/modules/service_accounts/main.tf
+++ b/infrastructure/gcp/modules/service_accounts/main.tf
@@ -17,9 +17,27 @@ resource "google_service_account_iam_binding" "nick_iam_binding" {
   ]
 }
 
-resource "google_project_iam_binding" "project" {
+resource "google_project_iam_binding" "editor_bindings" {
   project = var.project_id
   role    = "roles/editor"
+
+  members = [
+    "serviceAccount:application-user@${var.project_id}.iam.gserviceaccount.com",
+  ]
+}
+
+resource "google_project_iam_binding" "kubernetes_admin_bindings" {
+  project = var.project_id
+  role    = "roles/container.admin"
+
+  members = [
+    "serviceAccount:application-user@${var.project_id}.iam.gserviceaccount.com",
+  ]
+}
+
+resource "google_project_iam_binding" "service_account_user_bindings" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser"
 
   members = [
     "serviceAccount:application-user@${var.project_id}.iam.gserviceaccount.com",

--- a/infrastructure/kubernetes/main.tf
+++ b/infrastructure/kubernetes/main.tf
@@ -50,9 +50,7 @@ provider "kubernetes-alpha" {
   server_side_planning = true
 
   host = "https://${data.terraform_remote_state.gcp.outputs.gke_host}"
-
-  client_certificate     = base64decode(data.terraform_remote_state.gcp.outputs.gke_client_certificate)
-  client_key             = base64decode(data.terraform_remote_state.gcp.outputs.gke_client_key)
+  token                  = data.google_service_account_access_token.kubernetes_sa.access_token
   cluster_ca_certificate = base64decode(data.terraform_remote_state.gcp.outputs.gke_cluster_ca_certificate)
 }
 


### PR DESCRIPTION
Per the GCP docs, we are now giving the application-user K8 Engine admin
access and serviceAccountUser permissions