### PR TITLE
add service account for GitHub actions to TF

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -21,6 +21,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ secrets.GPR_USERNAME }}
+          password: ${{ secrets.GPR_PERSONAL_ACCESS_TOKEN }}
 
       - name: Build the Docker image
         run: |-
@@ -70,6 +76,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ secrets.GPR_USERNAME }}
+          password: ${{ secrets.GPR_PERSONAL_ACCESS_TOKEN }}
 
       - name: Build the Docker image
         run: |-
@@ -116,8 +128,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ secrets.GPR_USERNAME }}
+          password: ${{ secrets.GPR_PERSONAL_ACCESS_TOKEN }}
 
       - name: Build the Docker image
         run: |-

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -22,13 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: docker.pkg.github.com
-          username: ${{ secrets.GPR_USERNAME }}
-          password: ${{ secrets.GPR_PERSONAL_ACCESS_TOKEN }}
-
       - name: Build the Docker image
         run: |-
           docker build \
@@ -78,13 +71,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: docker.pkg.github.com
-          username: ${{ secrets.GPR_USERNAME }}
-          password: ${{ secrets.GPR_PERSONAL_ACCESS_TOKEN }}
-
       - name: Build the Docker image
         run: |-
           docker build \
@@ -132,13 +118,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@v1
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: docker.pkg.github.com
-          username: ${{ secrets.GPR_USERNAME }}
-          password: ${{ secrets.GPR_PERSONAL_ACCESS_TOKEN }}
 
       - name: Build the Docker image
         run: |-

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -17,8 +17,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ secrets.GPR_USERNAME }}
+          password: ${{ secrets.GPR_PERSONAL_ACCESS_TOKEN }}
 
       - name: Build the Docker image
         run: |-
@@ -68,8 +72,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ secrets.GPR_USERNAME }}
+          password: ${{ secrets.GPR_PERSONAL_ACCESS_TOKEN }}
 
       - name: Build the Docker image
         run: |-
@@ -116,8 +124,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ secrets.GPR_USERNAME }}
+          password: ${{ secrets.GPR_PERSONAL_ACCESS_TOKEN }}
 
       - name: Build the Docker image
         run: |-

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -1,5 +1,5 @@
 ---
-name: deploy_latest
+name: staging
 
 on:
   workflow_run:
@@ -19,13 +19,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@v1
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: docker.pkg.github.com
-          username: ${{ secrets.GPR_USERNAME }}
-          password: ${{ secrets.GPR_PERSONAL_ACCESS_TOKEN }}
 
       - name: Build the Docker image
         run: |-
@@ -78,13 +71,6 @@ jobs:
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@v1
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: docker.pkg.github.com
-          username: ${{ secrets.GPR_USERNAME }}
-          password: ${{ secrets.GPR_PERSONAL_ACCESS_TOKEN }}
-
       - name: Build the Docker image
         run: |-
           docker build \
@@ -132,13 +118,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@v1
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: docker.pkg.github.com
-          username: ${{ secrets.GPR_USERNAME }}
-          password: ${{ secrets.GPR_PERSONAL_ACCESS_TOKEN }}
 
       - name: Build the Docker image
         run: |-

--- a/infrastructure/gcp/modules/service_accounts/main.tf
+++ b/infrastructure/gcp/modules/service_accounts/main.tf
@@ -1,3 +1,13 @@
+resource "google_service_account" "github_actions_account" {
+  account_id   = "github-actions"
+  display_name = "GitHub Actions"
+  description  = "GCP Credentials used in GitHub Actions"
+}
+
+resource "google_service_account_key" "github_actions_account_key" {
+  service_account_id = google_service_account.github_actions_account.name
+}
+
 resource "google_service_account" "application_user_account" {
   account_id   = "application-user"
   display_name = "Application User"
@@ -14,6 +24,7 @@ resource "google_project_iam_binding" "editor_bindings" {
 
   members = [
     "serviceAccount:application-user@${var.project_id}.iam.gserviceaccount.com",
+    "serviceAccount:github-actions@${var.project_id}.iam.gserviceaccount.com",
     "serviceAccount:terraform@${var.project_id}.iam.gserviceaccount.com",
     "serviceAccount:${var.project_number}-compute@developer.gserviceaccount.com"
   ]

--- a/infrastructure/gcp/modules/service_accounts/outputs.tf
+++ b/infrastructure/gcp/modules/service_accounts/outputs.tf
@@ -1,3 +1,7 @@
 output "application_user_account_key" {
   value = google_service_account_key.application_user_account_key.private_key
 }
+
+output "github_actions_account_key" {
+  value = google_service_account_key.github_actions_account_key.private_key
+}

--- a/infrastructure/gcp/outputs.tf
+++ b/infrastructure/gcp/outputs.tf
@@ -60,6 +60,11 @@ output "application_user_account_key" {
   sensitive = true
 }
 
+output "github_actions_account_key" {
+  value     = module.service_accounts.github_actions_account_key
+  sensitive = true
+}
+
 output "database_name" {
   value = "neon-law"
 }


### PR DESCRIPTION
Also the single-source-of-truth key is created in TF that can then be
used in GitHub Actions.