### PR TITLE
remove handler use app.rb

### DIFF
--- a/infrastructure/gcp/modules/functions/main.tf
+++ b/infrastructure/gcp/modules/functions/main.tf
@@ -6,7 +6,6 @@ resource "google_cloudfunctions_function" "welcome_email" {
   available_memory_mb   = 256
   source_archive_bucket = var.source_archive_bucket
   source_archive_object = var.email_source_archive_object
-  entry_point           = "emails/handlers/welcome_email_handler.rb"
 
   event_trigger {
     event_type = "google.pubsub.topic.publish"


### PR DESCRIPTION
By default, Ruby Cloud Functions use app.rb.