### PR TITLE
use right version for email.zip

### DIFF
--- a/infrastructure/gcp/main.tf
+++ b/infrastructure/gcp/main.tf
@@ -123,7 +123,7 @@ module "functions" {
 
   source = "./modules/functions"
   source_archive_bucket = module.function_bucket.name
-  email_source_archive_object = "emails/${data.terraform_remote_state.versions.outputs["${var.environment}_blue_schemas"]}.zip"
+  email_source_archive_object = "emails/${data.terraform_remote_state.versions.outputs["${var.environment}_${each.key}_emails"]}.zip"
   color = each.key
   schema_version = each.value
   project_id     = var.project_id


### PR DESCRIPTION
With this change, we should see the right email needed for the GCP
function code.