### PR TITLE
deploy the schemas separate to blue/green

### DIFF
--- a/infrastructure/gcp/main.tf
+++ b/infrastructure/gcp/main.tf
@@ -97,15 +97,11 @@ module "secrets" {
 }
 
 module "pub_sub_topics" {
-  for_each = {
-    "green" = data.terraform_remote_state.versions.outputs["${var.environment}_green_schemas"]
-    "blue"  = data.terraform_remote_state.versions.outputs["${var.environment}_blue_schemas"]
-  }
+  for_each = toset( ["0.1.0", "0.1.1"] )
 
   source         = "./modules/pubsub"
   environment    = var.environment
-  color          = each.key
-  schema_version = each.value
+  schema_version = each.key
   project_id     = var.project_id
 }
 

--- a/infrastructure/gcp/modules/pubsub/variables.tf
+++ b/infrastructure/gcp/modules/pubsub/variables.tf
@@ -4,8 +4,5 @@ variable "environment" {
 variable "schema_version" {
 }
 
-variable "color" {
-}
-
 variable "project_id" {
 }


### PR DESCRIPTION
Instead of tying the schemas to colors, we can deploy every version of a
schema and have the topics ready to go whenever the services respond.