### PR TITLE
sync cloud messages to avro schemas

### DIFF
--- a/emails/app.rb
+++ b/emails/app.rb
@@ -4,6 +4,8 @@ require "logger"
 
 logger = Logger.new($stdout)
 
-FunctionsFramework.cloud_event "neon_law.welcome_email" do |event|
-  logger.info event
+WELCOME_EMAIL_TOPIC = "com.neon_law.outbound_email.welcome_email".freeze
+
+FunctionsFramework.cloud_event WELCOME_EMAIL_TOPIC do |event|
+  logger.info event.data
 end

--- a/emails/lib/neon_email/version.rb
+++ b/emails/lib/neon_email/version.rb
@@ -1,3 +1,3 @@
 module NeonEmail
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end

--- a/emails/spec/app_spec.rb
+++ b/emails/spec/app_spec.rb
@@ -6,12 +6,14 @@ RSpec.describe "app.rb" do
       load_temporary "${__dir__}/../app.rb" do
         event = make_cloud_event(
           {yes: "yes"}.to_json,
-          type: "neon_law.welcome_email"
+          type: "com.neon_law.outbound_email.welcome_email"
         )
 
-        expect_any_instance_of(Logger).to receive(:info).with(event)
+        expect_any_instance_of(Logger).to(
+          receive(:info).with({yes: "yes"}.to_json)
+        )
 
-        call_event("neon_law.welcome_email", event)
+        call_event("com.neon_law.outbound_email.welcome_email", event)
       end
     end
   end

--- a/infrastructure/gcp/modules/functions/main.tf
+++ b/infrastructure/gcp/modules/functions/main.tf
@@ -6,7 +6,7 @@ resource "google_cloudfunctions_function" "welcome_email" {
   available_memory_mb   = 256
   source_archive_bucket = var.source_archive_bucket
   source_archive_object = var.email_source_archive_object
-  entry_point           = "neon_law.welcome_email"
+  entry_point           = "com.neon_law.outbound_email.welcome_email"
 
   event_trigger {
     event_type = "google.pubsub.topic.publish"


### PR DESCRIPTION
every gcp message should be the same as the avro namespace and schema so we can further use avro as our source of truth.