### PR TITLE
parse 64 encoded message

### DIFF
--- a/emails/Gemfile.lock
+++ b/emails/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    neon_email (0.0.8)
+    neon_email (0.1.1)
       functions_framework (= 0.9.0)
       neon_schemas (= 0.1.1)
 

--- a/emails/app.rb
+++ b/emails/app.rb
@@ -1,11 +1,15 @@
 require "functions_framework"
 require "neon_email"
 require "logger"
+require "base64"
+require "json"
 
 logger = Logger.new($stdout)
 
 WELCOME_EMAIL_TOPIC = "com.neon_law.outbound_email.welcome_email".freeze
 
 FunctionsFramework.cloud_event WELCOME_EMAIL_TOPIC do |event|
-  logger.info event.data
+  data = JSON.parse(Base64.strict_decode64(event.data.fetch(:data)))
+
+  logger.info(data)
 end

--- a/emails/lib/neon_email/version.rb
+++ b/emails/lib/neon_email/version.rb
@@ -1,3 +1,3 @@
 module NeonEmail
-  VERSION = "0.0.9"
+  VERSION = "0.1.1"
 end

--- a/emails/spec/app_spec.rb
+++ b/emails/spec/app_spec.rb
@@ -1,17 +1,17 @@
-require "functions_framework"
-
 RSpec.describe "app.rb" do
   context "with a welcome_email event" do
     it "invokes the NeonEmail::Mailer#send_welcome_email" do
       load_temporary "${__dir__}/../app.rb" do
+        message = {"yes" => "yes"}
+
+        data = {"data": Base64.encode64(message.to_json).strip}
+
         event = make_cloud_event(
-          {yes: "yes"}.to_json,
+          data,
           type: "com.neon_law.outbound_email.welcome_email"
         )
 
-        expect_any_instance_of(Logger).to(
-          receive(:info).with({yes: "yes"}.to_json)
-        )
+        expect_any_instance_of(Logger).to receive(:info).with(message)
 
         call_event("com.neon_law.outbound_email.welcome_email", event)
       end

--- a/emails/spec/spec_helper.rb
+++ b/emails/spec/spec_helper.rb
@@ -3,6 +3,8 @@ require "neon_email"
 require "pry"
 require "faker"
 require "functions_framework/testing"
+require "functions_framework"
+require "base64"
 
 RSpec.configure do |config|
   config.include FunctionsFramework::Testing


### PR DESCRIPTION
when a message comes in from pubsub, it comes in as an object with a `:data` key. This key contains a base64 encoded dump of the avro-schemaed message.